### PR TITLE
Fix CSV streaming bug when JSON data not enabled AI-assisted, model u…

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -634,6 +634,9 @@ impl ResultsManager {
     pub fn enable_csv_streaming(&mut self, streaming_file: &Path) -> Result<()> {
         self.streaming_csv_file = Some(streaming_file.to_path_buf());
         self.csv_streaming_enabled = true;
+        // Enable per-message streaming so that records are actually written
+        self.per_message_streaming = true;
+        self.streaming_enabled = true;
 
         // Create/truncate the streaming file and write header
         let mut file = std::fs::OpenOptions::new()


### PR DESCRIPTION
Fix CSV streaming bug when JSON data not enabled AI-assisted, model used claude-4-sonnet

- Enable per-message streaming automatically in enable_csv_streaming()
- Ensures CSV records are written when using --streaming-output-csv alone
- Fixes issue where per_message_streaming flag wasn't set for CSV-only streaming

Fixes #17