### PR TITLE
chore(ci): pin actions to tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
@@ -93,7 +93,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@v1
 
     - name: Install Linux dependencies
       run: |
@@ -120,7 +120,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@v1
 
     - name: Install cargo-audit
       run: cargo install cargo-audit
@@ -138,7 +138,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@v1
 
     - name: Install Linux dependencies
       run: |
@@ -192,7 +192,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install MSRV Rust (1.70.0)
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: 1.70.0
 


### PR DESCRIPTION
Updates the CI workflows to use tagged releases for all GitHub Actions instead of branch names like master or stable.

This is a security best practice that ensures the workflow runs against a specific, immutable version of an action, preventing unexpected changes or potential supply chain attacks.

Specifically, all instances of `dtolnay/rust-toolchain` have been pinned to the `v1` release.

AI-assisted-by: Gemini 2.5 Pro