### PR TITLE
fix(ci): correctly expand variables in notifier comment

### DIFF
--- a/.github/workflows/stale-pr-notifier.yml
+++ b/.github/workflows/stale-pr-notifier.yml
@@ -29,17 +29,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMITS: ${{ steps.get_commits.outputs.commits }}
-          COMMENT_BODY: |
-            ⚠️ **This PR is out-of-date with the `main` branch.**
-
-            The base branch has been updated with new changes.
-
-            **Recent commits to `main`:**
-            ```
-            $COMMITS
-            ```
-
-            To ensure a clean merge, please rebase your branch on top of the latest `main` and push your changes.
         run: |
           for pr_number in $(gh pr list --state open --json number -q '.[].number'); do
             echo "Checking PR number $pr_number"
@@ -56,7 +45,24 @@ jobs:
               existing_comment=$(gh pr view $pr_number --json comments -q '.comments[] | select(.body | contains("This PR is out-of-date")) | .id')
               
               if [ -z "$existing_comment" ]; then
-                gh pr comment "$pr_number" --body "$COMMENT_BODY"
+                # Define the multiline body inside the script to ensure $COMMITS is expanded
+                BODY="⚠️ **This PR is out-of-date with the 
+main
+ branch.**
+
+                The base branch has been updated with new changes.
+
+                **Recent commits to 
+main
+:**
+                ```
+                $COMMITS
+                ```
+
+                To ensure a clean merge, please rebase your branch on top of the latest 
+main
+ and push your changes."
+                gh pr comment "$pr_number" --body "$BODY"
               else
                 echo "A stale comment already exists on PR #$pr_number. Skipping."
               fi


### PR DESCRIPTION
Resolves an issue where the stale PR notifier comment was displaying the literal variable name `$COMMITS` instead of its value.

The fix moves the multiline string definition from the steps `env` block into the `run` script itself. This ensures that the shell correctly expands the embedded variable at execution time.

AI-assisted-by: Gemini 2.5 Pro