### PR TITLE
refactor(ci): separate linting and formatting into a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,52 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  lint_and_format:
+    name: Lint and Format
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+
+    - name: Cache cargo index
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-index-
+
+    - name: Cache cargo target
+      uses: actions/cache@v4
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-build-target-
+
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+    - name: Check with clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
+
   test:
     name: Test
+    needs: lint_and_format
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,7 +80,6 @@ jobs:
       uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
-        components: rustfmt, clippy
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -67,12 +110,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential pkg-config
-
-    - name: Check formatting
-      run: cargo fmt --all -- --check
-
-    - name: Check with clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: Run tests
       run: cargo test --verbose --all-features


### PR DESCRIPTION
Restructures the CI workflow to provide clearer and faster feedback.

- A new `lint_and_format` job has been created to run `cargo fmt` and `cargo clippy`. Since these checks are platform-independent, this job runs only once on Ubuntu.

- The `test` job now depends on the `lint_and_format` job and no longer contains the formatting or linting steps.

This change ensures that basic code quality checks must pass before the full test matrix is initiated, saving CI time and making the cause of failures more obvious.

AI-assisted-by: Gemini 2.5 Pro