### PR TITLE
ci(fmt): improve formatting check to output a diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           ${{ runner.os }}-cargo-build-target-
 
     - name: Check formatting
-      run: cargo fmt --all -- --check
+      run: cargo fmt --all -- --check --emit=diff
 
     - name: Check with clippy
       run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Updates the `cargo fmt` command to use the `--emit=diff` flag.

This provides a much better user experience for formatting failures. Instead of a long list of checked files, the CI log will now only show output if a file needs formatting, and that output will be a clear, actionable diff of the required changes.

AI-assisted-by: Gemini 2.5 Pro