### PR TITLE
fix(ci): correct yaml syntax in stale pr notifier

### DIFF
--- a/.github/workflows/stale-pr-notifier.yml
+++ b/.github/workflows/stale-pr-notifier.yml
@@ -45,23 +45,19 @@ jobs:
               existing_comment=$(gh pr view $pr_number --json comments -q '.comments[] | select(.body | contains("This PR is out-of-date")) | .id')
               
               if [ -z "$existing_comment" ]; then
-                # Define the multiline body inside the script to ensure $COMMITS is expanded
-                BODY="⚠️ **This PR is out-of-date with the 
-main
- branch.**
+                # Define the multiline body using a here document to ensure proper expansion and formatting
+                read -r -d '' BODY <<EOF
+⚠️ **This PR is out-of-date with the `main` branch.**
 
-                The base branch has been updated with new changes.
+The base branch has been updated with new changes.
 
-                **Recent commits to 
-main
-:**
-                ```
-                $COMMITS
-                ```
+**Recent commits to `main`:**
+```
+$COMMITS
+```
 
-                To ensure a clean merge, please rebase your branch on top of the latest 
-main
- and push your changes."
+To ensure a clean merge, please rebase your branch on top of the latest `main` and push your changes.
+EOF
                 gh pr comment "$pr_number" --body "$BODY"
               else
                 echo "A stale comment already exists on PR #$pr_number. Skipping."


### PR DESCRIPTION
Resolves a YAML syntax error in the stale PR notifier workflow.

The multiline string for the comment body was causing parsing issues. This has been fixed by using a "here document" (`<<EOF`), which is a more robust and reliable way to define multiline strings with variable expansion inside shell scripts within a YAML file.

This change also restores the correct markdown for the `main` branch name in the comment.

AI-assisted-by: Gemini 2.5 Pro