### PR TITLE
ci(lint): improve linting job feedback and resilience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,17 @@ jobs:
           ${{ runner.os }}-cargo-build-target-
 
     - name: Check formatting
-      run: cargo fmt --all -- --check --emit=diff
+      run: |
+        if ! cargo fmt --all -- --check --emit=diff; then
+          echo "----------------------------------------------------------------"
+          echo "ERROR: Code formatting issues detected."
+          echo "Please run 'cargo fmt --all' locally and commit the changes."
+          echo "----------------------------------------------------------------"
+          exit 1
+        fi
 
     - name: Check with clippy
+      if: always()
       run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:


### PR DESCRIPTION
Improves the user experience of the `lint_and_format` job.

- The `cargo fmt` step now prints a clear, helpful error message on failure, instructing the user on how to fix the issue.
- The `clippy` step is now configured with `if: always()` to ensure it runs even if the formatting check fails.

This allows developers to see all formatting and linting feedback in a single CI run, making the process more efficient.

AI-assisted-by: Gemini 2.5 Pro