### PR TITLE
feat(ci): implement self-contained coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        # Fetch the full history to allow diff-coverage checking
+        fetch-depth: 0
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@v1
@@ -256,13 +259,38 @@ jobs:
       run: cargo install cargo-tarpaulin
 
     - name: Generate coverage report
-      run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+      run: |
+        cargo tarpaulin \
+          --verbose \
+          --all-features \
+          --workspace \
+          --branch \
+          --timeout 120 \
+          --out Xml \
+          --output-dir ./coverage-reports \
+          | tee ./coverage-reports/coverage-summary.txt
 
-    - name: Upload to codecov.io
-      uses: codecov/codecov-action@v4
+    - name: Archive coverage report
+      uses: actions/upload-artifact@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false
+        name: coverage-report
+        path: |
+          ./coverage-reports/cobertura.xml
+          ./coverage-reports/coverage-summary.txt
+        retention-days: 1
+
+    - name: Post detailed coverage summary to Job Summary
+      run: |
+        echo "### Code Coverage Report" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '<details><summary>Click to expand for a detailed, per-file coverage report</summary>' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '```text' >> $GITHUB_STEP_SUMMARY
+        # The text report from tarpaulin has color codes, so we remove them with sed
+        sed 's/\[0-9;]*m//g' ./coverage-reports/coverage-summary.txt >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '</details>' >> $GITHUB_STEP_SUMMARY
 
   benchmarks:
     name: Performance Benchmarks
@@ -318,4 +346,29 @@ jobs:
 
     - name: Test container image
       run: podman run --rm ipc-benchmark --help
+
+  coverage_pr_comment:
+    name: Post PR Coverage Comment
+    runs-on: ubuntu-latest
+    needs: coverage
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: ./coverage-reports
+
+      - name: Post coverage comment
+        uses: MADHEAD/cobertura-report-action@v2
+        with:
+          path: ./coverage-reports/cobertura.xml
+          threshold: 0 # We only post the report, not fail the job
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          skip_covered: true
+          show_missing: true
+          show_branch: true
+          minimum_coverage: 70 # This is for display only
+          report_name: 'Code Coverage Report'
 


### PR DESCRIPTION
This commit replaces the external Codecov service with a fully self-contained code coverage solution within GitHub Actions.

- The 'coverage' job is updated to generate a detailed, per-file text report and a Cobertura XML file. The text report is posted to the Job Summary in a collapsible section for every workflow run.
- A new 'coverage_pr_comment' job is added, which runs only on pull requests. It uses the generated XML report to post a concise, diff-aware coverage summary as a PR comment.

AI-assisted-by: Gemini 2.5 Pro