### PR TITLE
fix(ci): Correct artifact download path in coverage comment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
         with open("./coverage-reports/coverage-summary.md", "w") as f:
             f.write("### 📊 Code Coverage Summary\n\n")
             f.write("| File | Line Coverage | Branch Coverage | Uncovered Lines |\n")
-            f.write("|------|---------------|-----------------|-----------------|")
+            f.write("|------|---------------|-----------------|-----------------|\n")
 
             packages = root.find("packages")
             all_classes = []
@@ -331,7 +331,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
-          path: .
+          path: ./coverage-reports
 
       - name: Post Coverage Comment
         env:


### PR DESCRIPTION
The coverage_pr_comment job was failing because the download-artifact step placed all files from the artifact into the workspace root, while the subsequent script expected the summary file to be inside the ./coverage-reports/ directory.

This commit updates the download path to './coverage-reports', ensuring the artifact contents are extracted into the correct subdirectory, resolving the "No such file or directory" error.

AI-assisted-by: Gemini 2.5 Pro