### PR TITLE
fix(ci): Correct branch coverage and artifact path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
           --all-features \
           --workspace \
           --branch \
+          --engine llvm \
           --timeout 120 \
           --out Xml \
           --color never \
@@ -331,7 +332,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
-          path: ./coverage-reports
+          path: .
 
       - name: Post Coverage Comment
         env:


### PR DESCRIPTION
This commit includes two important fixes for the CI workflow:

1.  **Use llvm engine for accurate branch coverage:** The default ptrace engine for cargo-tarpaulin was reporting 0% branch coverage. This commit switches to the `llvm` engine, which uses LLVM's own coverage instrumentation for more reliable and accurate branch coverage metrics.

2.  **Correct artifact download path in coverage comment job:** The `coverage_pr_comment` job was failing because it could not find the summary file. The artifact download path has been corrected from `./coverage-reports` to `.` to ensure the `coverage-reports` directory is created in the workspace root as expected.

AI-assisted-by: Gemini 2.5 Pro