### PR TITLE
feat(affinity): Add CPU affinity for client and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +580,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "core_affinity",
  "criterion",
  "crossbeam",
  "hdrhistogram",
@@ -1506,6 +1518,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1541,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tracing-appender = "0.2.3"
 time = ">=0.3.34, <0.3.36" # Pinned to a compatible range for MSRV 1.70
 parking_lot = "0.12.4"
 thiserror = "2.0.16"
+core_affinity = "0.8.3"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ ipc-benchmark -m tcp --host 127.0.0.1 --port 9090
 ipc-benchmark -m shm --buffer-size 16384
 ```
 
+### CPU Affinity
+
+For the most stable and repeatable results, you can pin the server and client processes to specific CPU cores. This minimizes performance noise from OS scheduling, context switching, and cache misses.
+
+- `--server-affinity <CORE_ID>`: Pins the server process to a specific CPU core.
+- `--client-affinity <CORE_ID>`: Pins the client process to a specific CPU core.
+
+```bash
+# Pin the server to core 2 and the client to core 3
+ipc-benchmark \
+  -m uds \
+  -i 100000 \
+  --server-affinity 2 \
+  --client-affinity 3
+```
+
 ### Test Configuration Examples
 
 #### High-Throughput Testing
@@ -564,4 +580,3 @@ Common issues and solutions:
 - **Single-threaded** (`-c 1`): Most accurate latency measurements
 - **Simulated concurrency** (`-c 2+`): Good for throughput scaling analysis
 - **Shared memory**: Always single-threaded for reliability
-

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -323,6 +323,16 @@ impl BenchmarkRunner {
         } else {
             info!("  Message Count:      {}", self.get_msg_count());
         }
+        let server_affinity_str = self
+            .config
+            .server_affinity
+            .map_or("Not set".to_string(), |c| c.to_string());
+        let client_affinity_str = self
+            .config
+            .client_affinity
+            .map_or("Not set".to_string(), |c| c.to_string());
+        info!("  Server Affinity:    {}", server_affinity_str);
+        info!("  Client Affinity:    {}", client_affinity_str);
         info!("-----------------------------------------------------------------");
 
         // Initialize results structure with test configuration

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -775,7 +775,7 @@ mod tests {
     /// Test parsing of CPU affinity arguments
     #[test]
     fn test_parse_affinity_args() {
-        let args = Args::parse_from(&[
+        let args = Args::parse_from([
             "ipc-benchmark",
             "--server-affinity",
             "2",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,7 @@ fn styles() -> Styles {
 // Define constants for help headings to ensure consistency.
 const TIMING: &str = "Timing";
 const CONCURRENCY: &str = "Concurrency";
+const AFFINITY: &str = "Affinity";
 const OUTPUT_AND_LOGGING: &str = "Output and Logging";
 const ADVANCED: &str = "Advanced";
 
@@ -148,14 +149,14 @@ pub struct Args {
     ///
     /// Specifies the CPU core to which the server process should be pinned.
     /// Pinning can reduce cache misses and context switching, improving performance.
-    #[arg(long, help_heading = CONCURRENCY)]
+    #[arg(long, help_heading = AFFINITY)]
     pub server_affinity: Option<usize>,
 
     /// Client CPU affinity.
     ///
     /// Specifies the CPU core to which the client process should be pinned.
     /// Pinning can reduce cache misses and context switching, improving performance.
-    #[arg(long, help_heading = CONCURRENCY)]
+    #[arg(long, help_heading = AFFINITY)]
     pub client_affinity: Option<usize>,
 
     /// Path to the final JSON output file. If used without a path, defaults to 'benchmark_results.json'.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@
 //!             buffer_size: Some(8192),
 //!             host: "127.0.0.1".to_string(),
 //!             port: 8080,
+//!             server_affinity: None,
+//!             client_affinity: None,
 //!         };
 //!     
 //!         let runner = BenchmarkRunner::new(config, IpcMechanism::UnixDomainSocket);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,68 @@
 //! - **Performance**: Minimal overhead for frequently called functions
 //! - **Extensibility**: Easy to add new formatters and validators
 
+use anyhow::{anyhow, Result};
+use std::future::Future;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::warn;
+
+/// Spawns a Tokio task on a new thread with a specific CPU affinity.
+///
+/// If `core_id` is `Some`, this function will create a new thread, pin it to the
+/// specified CPU core, and then spawn the given future on a single-threaded Tokio
+/// runtime on that thread.
+///
+/// If `core_id` is `None`, it will spawn the future on the default Tokio runtime
+/// without any specific affinity.
+///
+/// # Arguments
+///
+/// * `future` - The future to execute.
+/// * `core_id` - The ID of the CPU core to pin the thread to.
+///
+/// # Returns
+///
+/// A `JoinHandle` for the spawned task.
+pub async fn spawn_with_affinity<F, T>(future: F, core_id: Option<usize>) -> Result<T>
+where
+    F: Future<Output = Result<T>> + Send + 'static,
+    T: Send + 'static,
+{
+    match core_id {
+        Some(id) => {
+            let handle = tokio::task::spawn_blocking(move || {
+                let core_ids = core_affinity::get_core_ids().ok_or_else(|| {
+                    anyhow!("Failed to get core IDs, is this a supported platform?")
+                })?;
+
+                if core_ids.is_empty() {
+                    return Err(anyhow!("No available CPU cores found."));
+                }
+
+                let target_core = core_ids.get(id).ok_or_else(|| {
+                    anyhow!(
+                        "Invalid core ID: {}. System has {} available cores (valid IDs are 0 to {}).",
+                        id,
+                        core_ids.len(),
+                        core_ids.len() - 1
+                    )
+                })?;
+
+                if !core_affinity::set_for_current(*target_core) {
+                    warn!("Failed to set affinity for core ID: {}", id);
+                }
+
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()?;
+                rt.block_on(future)
+            });
+            handle.await?
+        }
+        None => future.await,
+    }
+}
 
 /// Get current timestamp as nanoseconds since Unix epoch
 ///
@@ -54,4 +115,75 @@ pub fn current_timestamp_ns() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    /// Test that a future can be spawned with affinity and its result retrieved.
+    #[tokio::test]
+    async fn test_spawn_with_affinity_retrieves_result() {
+        let future = async { Ok("Hello from thread") };
+        // Spawn on core 0 if available, otherwise fallback to no affinity
+        let core_id = if core_affinity::get_core_ids().is_some() {
+            Some(0)
+        } else {
+            None
+        };
+        let result = spawn_with_affinity(future, core_id).await.unwrap();
+        assert_eq!(result, "Hello from thread");
+    }
+
+    /// Test that spawning with a specific core ID runs the future on a different thread.
+    #[tokio::test]
+    async fn test_spawn_with_affinity_uses_new_thread() {
+        let main_thread_id = thread::current().id();
+        let future = async move { Ok(thread::current().id()) };
+
+        // Spawn on core 0 if available, otherwise fallback to no affinity.
+        // This test is most meaningful when a core is available.
+        let core_id = if core_affinity::get_core_ids().is_some() {
+            Some(0)
+        } else {
+            None
+        };
+
+        if core_id.is_some() {
+            let future_thread_id = spawn_with_affinity(future, core_id).await.unwrap();
+            assert_ne!(
+                main_thread_id, future_thread_id,
+                "Future should have run on a different thread"
+            );
+        } else {
+            // If we can't test with affinity, we can't guarantee a new thread.
+            // Tokio's default scheduler might run it on the same thread.
+            // We'll just log a warning that the main part of the test was skipped.
+            warn!("Could not get core IDs, skipping new-thread-id check in test_spawn_with_affinity_uses_new_thread");
+        }
+    }
+
+    /// Test that an invalid core ID returns a descriptive error message.
+    #[tokio::test]
+    async fn test_spawn_with_affinity_invalid_core_id() {
+        let future = async { Ok(()) };
+        // Use an impossibly high core ID
+        let core_id = Some(9999);
+
+        // This test should only run on systems where we can actually get core IDs
+        if let Some(cores) = core_affinity::get_core_ids() {
+            let result = spawn_with_affinity(future, core_id).await;
+            assert!(result.is_err());
+            let error_message = result.err().unwrap().to_string();
+            let expected_message = format!(
+                "Invalid core ID: 9999. System has {} available cores (valid IDs are 0 to {}).",
+                cores.len(),
+                cores.len() - 1
+            );
+            assert_eq!(error_message, expected_message);
+        } else {
+            warn!("Could not get core IDs, skipping invalid-core-id check in test_spawn_with_affinity_invalid_core_id");
+        }
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,11 +51,11 @@ where
 {
     match core_id {
         Some(id) => {
-            let handle = tokio::task::spawn_blocking(move || {
-                let core_ids = core_affinity::get_core_ids().ok_or_else(|| {
-                    anyhow!("Failed to get core IDs, is this a supported platform?")
-                })?;
+            // Get the core IDs from the current thread, which is assumed to have an unrestricted view.
+            let core_ids = core_affinity::get_core_ids()
+                .ok_or_else(|| anyhow!("Failed to get core IDs, is this a supported platform?"))?;
 
+            let handle = tokio::task::spawn_blocking(move || {
                 if core_ids.is_empty() {
                     return Err(anyhow!("No available CPU cores found."));
                 }


### PR DESCRIPTION
Depends on PR #68 

## Description
This pull request introduces CPU affinity pinning for both the client and server tasks, allowing
  for more stable and repeatable benchmark results by minimizing OS scheduling noise. It also
  includes a series of fixes to resolve build failures and logic errors that arose during the
  implementation.

  Key Changes:
   * CPU Affinity:
       * Introduced `--server-affinity <CORE_ID>` to pin the server task to a specific CPU core.
       * Introduced `--client-affinity <CORE_ID>` to pin the client task to a specific CPU core.
       * Added the `core_affinity` crate to manage this functionality.
   * Improved Validation: The error message for an invalid (out-of-bounds) core ID is descriptive.
   * Documentation: The `README.md` has been updated to include instructions on how to use the new CPU
     affinity flags.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally
- [x] Added tests for new functionality
- [x] Updated documentation

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No breaking changes (or marked as breaking)
