### PR TITLE
fix(ci): Correctly handle multiline output in coverage comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,11 @@ jobs:
         id: pr_coverage_check
         run: |
           set -e
-          echo "PR_COVERAGE_REPORT=$(./.github/scripts/check_pr_coverage.py ${{ github.base_ref }})" >> $GITHUB_OUTPUT
+          {
+            echo 'PR_COVERAGE_REPORT<<EOF'
+            ./.github/scripts/check_pr_coverage.py ${{ github.base_ref }}
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post Coverage Comment
         env:


### PR DESCRIPTION
The previous method of setting the GitHub Actions output variable was failing due to special characters and multiline strings in the output of the python script. This change uses a heredoc to correctly handle the multiline output.

AI-assisted-by: Gemini 2.5 Pro