### PR TITLE
fix(ci): Pass coverage report as an environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,10 +371,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_COVERAGE_REPORT: ${{ steps.pr_coverage_check.outputs.PR_COVERAGE_REPORT }}
         run: |
           MARKER="<!-- gemini-coverage-comment -->"
           BODY=$(cat ./coverage-reports/coverage-summary.md)
-          PR_COVERAGE_REPORT="${{ steps.pr_coverage_check.outputs.PR_COVERAGE_REPORT }}"
           
           COMMENT_BODY="$MARKER
           $PR_COVERAGE_REPORT


### PR DESCRIPTION
This prevents the shell from interpreting the contents of the coverage report as commands.

AI-assisted-by: Gemini 2.5 Pro