### PR TITLE
Fix/streaming timestamps

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -27,6 +27,12 @@ This document provides detailed information about configuring the IPC Benchmark 
 
 ### Test Configuration
 
+One-way and round-trip tests run **sequentially**, not
+simultaneously. Each test spawns its own server process, runs to
+completion, and tears down before the next test starts. By default
+both are enabled. For duration-based tests (`-d`), each test gets
+its own full time window.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--one-way` | Boolean | `true` | Enable one-way latency tests |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,16 @@ This benchmark suite provides a systematic way to evaluate the performance of va
 ### Output Formats
 
 - **JSON**: Optional, machine-readable structured output for final, aggregated results. Generated only when the `--output-file` flag is used.
-- **Streaming JSON**: Real-time, per-message latency data written to a file in a columnar JSON format. This allows for efficient, live monitoring of long-running tests. The format consists of a `headings` array and a `data` array containing value arrays for each message.
-- **Streaming CSV**: Real-time, per-message latency data written to a standard CSV file. This format is ideal for easy import into spreadsheets and data analysis tools.
+- **Streaming JSON**: Real-time, per-message latency data written
+  to a file in a columnar JSON format. This allows for efficient,
+  live monitoring of long-running tests. The format consists of a
+  `headings` array and a `data` array containing value arrays for
+  each message. See [Streaming Output Columns](#streaming-output-columns)
+  for the column definitions.
+- **Streaming CSV**: Real-time, per-message latency data written
+  to a standard CSV file. The columns match the streaming JSON
+  headings. This format is ideal for easy import into spreadsheets
+  and data analysis tools.
 - **Console Output**: User-friendly, color-coded summaries on `stdout`. Includes a configuration summary at startup and a detailed results summary upon completion.
 - **Detailed Logs**: Structured, timestamped logs written to a file or `stderr` for diagnostics.
 
@@ -196,6 +204,28 @@ send-wait-receive per message).
 2. **Server Side**: Receives request, sends response immediately
 3. **Client Side**: Timestamp captured after receiving response
 4. **Latency Calculation**: Total elapsed time from send to receive
+
+#### Streaming Output Columns
+
+The per-message streaming output (JSON and CSV) contains the
+following columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `timestamp_ns` | `u64` | Approximate wall-clock time (nanoseconds since Unix epoch) when the message was sent. For round-trip and combined tests this is captured on the client immediately before `send()`. For one-way tests the server approximates it as `wall_clock_now - latency`. |
+| `message_id` | `u64` | Zero-based sequential message identifier. |
+| `mechanism` | `string` | IPC mechanism name (e.g. `"TcpSocket"`, `"UnixDomainSocket"`). |
+| `message_size` | `u64` | Payload size in bytes. |
+| `one_way_latency_ns` | `u64` or `null` | One-way latency in nanoseconds, or `null` if this record is round-trip only. |
+| `round_trip_latency_ns` | `u64` or `null` | Round-trip latency in nanoseconds, or `null` if this record is one-way only. |
+
+> **Note on `timestamp_ns` accuracy:** For one-way tests the
+> server computes the send timestamp by subtracting the measured
+> monotonic latency from its current wall-clock time. This mixes
+> two clock domains (wall-clock and monotonic) and is subject to
+> minor drift from NTP adjustments, but it is the best
+> approximation available without clock synchronization between
+> the client and server processes.
 
 ### What's Measured
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,24 @@ This benchmark suite uses **high-precision monotonic clocks** to measure true IP
 - **Windows**: Falls back to system time (less precise)
 - **Characteristics**: Monotonic clocks measure time from system boot and are unaffected by NTP adjustments, daylight saving time, or manual clock changes
 
+#### Test Execution Order
+
+One-way and round-trip tests run **sequentially**, never
+simultaneously. Each test spawns its own server process, runs to
+completion, and tears down before the next test starts:
+
+1. **Warmup** (if configured)
+2. **One-way test** — client sends messages; server measures
+   receive latency
+3. **Round-trip test** — client sends a message, waits for the
+   server's response, then sends the next
+
+By default both tests are enabled. Use `--one-way` or
+`--round-trip` to run only one. For duration-based tests (`-d`),
+each test gets its own full time window, so one-way typically
+produces far more records than round-trip (fire-and-forget vs
+send-wait-receive per message).
+
 #### Timestamp Capture Points
 
 **For One-Way Latency Tests:**
@@ -390,7 +408,8 @@ ipc-benchmark --log-file stderr
 # Continue running tests even if one mechanism fails
 ipc-benchmark -m all --continue-on-error
 
-# Run only round-trip tests
+# Run only round-trip tests (one-way and round-trip run
+# sequentially by default; use these flags to select one)
 ipc-benchmark --round-trip --no-one-way
 
 # Custom percentiles for latency analysis

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -2632,4 +2632,104 @@ mod tests {
             );
         }
     }
+
+    /// Exercises the one-way streaming path with per-message
+    /// streaming enabled (not combined mode), covering the
+    /// send_timestamp_ns capture in run_one_way_test.
+    #[tokio::test]
+    async fn test_one_way_streaming_captures_send_timestamp() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let args = Args {
+            mechanisms: vec![{
+                #[cfg(unix)]
+                {
+                    IpcMechanism::UnixDomainSocket
+                }
+                #[cfg(not(unix))]
+                {
+                    IpcMechanism::TcpSocket
+                }
+            }],
+            message_size: 64,
+            msg_count: 5,
+            duration: None,
+            concurrency: 1,
+            warmup_iterations: 0,
+            one_way: true,
+            round_trip: false,
+            include_first_message: true,
+            ..Default::default()
+        };
+        let config = BenchmarkConfig::from_args(&args).unwrap();
+        let mechanism = args.mechanisms[0];
+        let runner = BenchmarkRunner::new(config, mechanism, args.clone());
+
+        let mut rm = crate::results::ResultsManager::new(None, None).unwrap();
+        rm.enable_per_message_streaming(&path).unwrap();
+
+        let res = runner.run(Some(&mut rm)).await;
+        assert!(res.is_ok(), "one-way streaming run failed: {:?}", res.err());
+        rm.finalize().await.unwrap();
+
+        let s = std::fs::read_to_string(&path).expect("read streaming file");
+        assert!(
+            s.contains("\"headings\""),
+            "Streaming output should have headings"
+        );
+        assert!(s.contains("\"data\""), "Streaming output should have data");
+    }
+
+    /// Exercises the round-trip streaming path with per-message
+    /// streaming enabled (not combined mode), covering the
+    /// send_timestamp_ns capture in run_round_trip_test.
+    #[tokio::test]
+    async fn test_round_trip_streaming_captures_send_timestamp() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let args = Args {
+            mechanisms: vec![{
+                #[cfg(unix)]
+                {
+                    IpcMechanism::UnixDomainSocket
+                }
+                #[cfg(not(unix))]
+                {
+                    IpcMechanism::TcpSocket
+                }
+            }],
+            message_size: 64,
+            msg_count: 5,
+            duration: None,
+            concurrency: 1,
+            warmup_iterations: 0,
+            one_way: false,
+            round_trip: true,
+            include_first_message: true,
+            ..Default::default()
+        };
+        let config = BenchmarkConfig::from_args(&args).unwrap();
+        let mechanism = args.mechanisms[0];
+        let runner = BenchmarkRunner::new(config, mechanism, args.clone());
+
+        let mut rm = crate::results::ResultsManager::new(None, None).unwrap();
+        rm.enable_per_message_streaming(&path).unwrap();
+
+        let res = runner.run(Some(&mut rm)).await;
+        assert!(
+            res.is_ok(),
+            "round-trip streaming run failed: {:?}",
+            res.err()
+        );
+        rm.finalize().await.unwrap();
+
+        let s = std::fs::read_to_string(&path).expect("read streaming file");
+        assert!(
+            s.contains("\"headings\""),
+            "Streaming output should have headings"
+        );
+        assert!(s.contains("\"data\""), "Streaming output should have data");
+    }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -234,6 +234,35 @@ pub struct BenchmarkConfig {
     pub client_affinity: Option<usize>,
 }
 
+/// Parse a line from the server-written latency file.
+///
+/// The expected format is `"wall_send_ns,latency_ns"` where
+/// `wall_send_ns` is the approximate wall-clock time the message
+/// was sent (computed server-side as `wall_now - latency`) and
+/// `latency_ns` is the measured one-way IPC latency in nanoseconds.
+///
+/// # Errors
+///
+/// Returns an error if the line does not contain exactly two
+/// comma-separated `u64` values.
+pub fn parse_latency_file_line(line: &str) -> anyhow::Result<(u64, u64)> {
+    let parts: Vec<&str> = line.splitn(2, ',').collect();
+    if parts.len() != 2 {
+        anyhow::bail!(
+            "Invalid latency file line (expected \
+             wall_send_ns,latency_ns): {}",
+            line
+        );
+    }
+    let wall_send_ns: u64 = parts[0]
+        .parse()
+        .with_context(|| format!("Failed to parse wall_send_ns from: {}", parts[0]))?;
+    let latency_ns: u64 = parts[1]
+        .parse()
+        .with_context(|| format!("Failed to parse latency_ns from: {}", parts[1]))?;
+    Ok((wall_send_ns, latency_ns))
+}
+
 impl BenchmarkConfig {
     /// Create benchmark configuration from CLI arguments
     ///
@@ -1117,27 +1146,22 @@ port={}",
             .await
             .context("Failed to read line from latency file")?
         {
-            let latency_ns: u64 = line
-                .parse()
-                .with_context(|| format!("Failed to parse latency from line: {}", line))?;
+            // Parse "wall_send_ns,latency_ns" format written
+            // by the server process.
+            let (wall_send_ns, latency_ns) = parse_latency_file_line(&line)?;
 
             let latency = Duration::from_nanos(latency_ns);
 
-            // Record in metrics collector
             metrics_collector.record_message(self.config.message_size, Some(latency))?;
 
-            // Stream latency if enabled
             if let Some(ref mut manager) = results_manager {
-                // Use current timestamp since this is server-measured latency read from file
-                let send_timestamp_ns =
-                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new(
                     line_num,
                     self.mechanism,
                     self.config.message_size,
                     crate::metrics::LatencyType::OneWay,
                     latency,
-                    send_timestamp_ns,
+                    wall_send_ns,
                 );
                 manager.stream_latency_record(&record).await?;
             }
@@ -1192,7 +1216,7 @@ port={}",
         let transport_config_clone = transport_config.clone();
 
         let client_future = async move {
-            let mut latencies = Vec::new();
+            let mut latencies: Vec<(Duration, u64)> = Vec::new();
             client_transport
                 .start_client(&transport_config_clone)
                 .await?;
@@ -1210,6 +1234,7 @@ port={}",
                 }
 
                 while start_time.elapsed() < duration {
+                    let wall_ts = crate::results::MessageLatencyRecord::current_timestamp_ns();
                     let send_time = Instant::now();
                     let message = Message::new(i, payload.clone(), MessageType::Request);
 
@@ -1231,7 +1256,7 @@ port={}",
                             .await
                             .is_ok()
                             {
-                                latencies.push(send_time.elapsed());
+                                latencies.push((send_time.elapsed(), wall_ts));
                             }
                         }
                         _ => {
@@ -1247,6 +1272,7 @@ port={}",
                     msg_count + 1
                 };
                 for i in 0..iterations {
+                    let wall_ts = crate::results::MessageLatencyRecord::current_timestamp_ns();
                     let send_time = Instant::now();
                     let message = Message::new(i as u64, payload.clone(), MessageType::Request);
                     client_transport.send(&message).await?;
@@ -1255,31 +1281,28 @@ port={}",
                     }
                     client_transport.receive().await?;
                     if i > 0 || client_config.include_first_message {
-                        latencies.push(send_time.elapsed());
+                        latencies.push((send_time.elapsed(), wall_ts));
                     }
                 }
             }
             client_transport.close().await?;
-            Ok::<Vec<Duration>, anyhow::Error>(latencies)
+            Ok::<Vec<(Duration, u64)>, anyhow::Error>(latencies)
         };
 
         // Execute client work with proper affinity using spawn_with_affinity
         let latencies =
             crate::utils::spawn_with_affinity(client_future, self.config.client_affinity).await?;
 
-        for (i, latency) in latencies.iter().enumerate() {
+        for (i, (latency, wall_ts)) in latencies.iter().enumerate() {
             metrics_collector.record_message(self.config.message_size, Some(*latency))?;
             if let Some(ref mut manager) = results_manager {
-                // Use current timestamp since latencies are recorded after collection
-                let send_timestamp_ns =
-                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new(
                     i as u64,
                     self.mechanism,
                     self.config.message_size,
                     crate::metrics::LatencyType::RoundTrip,
                     *latency,
-                    send_timestamp_ns,
+                    *wall_ts,
                 );
                 manager.stream_latency_record(&record).await?;
             }
@@ -1510,8 +1533,8 @@ port={}",
         let transport_config_clone = transport_config.clone();
 
         let client_future = async move {
-            let mut one_way_latencies = Vec::new();
-            let mut round_trip_latencies = Vec::new();
+            let mut one_way_latencies: Vec<(Duration, u64)> = Vec::new();
+            let mut round_trip_latencies: Vec<Duration> = Vec::new();
             client_transport
                 .start_client(&transport_config_clone)
                 .await?;
@@ -1522,6 +1545,7 @@ port={}",
             if let Some(duration) = client_config.duration {
                 let mut i = 0u64;
                 while start_time.elapsed() < duration {
+                    let wall_ts = crate::results::MessageLatencyRecord::current_timestamp_ns();
                     let send_start = Instant::now();
                     let message = Message::new(i, payload.clone(), MessageType::Request);
 
@@ -1529,7 +1553,7 @@ port={}",
                         let one_way_latency = send_start.elapsed();
                         if client_transport.receive().await.is_ok() {
                             let round_trip_latency = send_start.elapsed();
-                            one_way_latencies.push(one_way_latency);
+                            one_way_latencies.push((one_way_latency, wall_ts));
                             round_trip_latencies.push(round_trip_latency);
                             i += 1;
                         } else {
@@ -1542,48 +1566,46 @@ port={}",
             } else {
                 let msg_count = client_config.msg_count.unwrap_or_default();
                 for i in 0..msg_count {
+                    let wall_ts = crate::results::MessageLatencyRecord::current_timestamp_ns();
                     let send_start = Instant::now();
                     let message = Message::new(i as u64, payload.clone(), MessageType::Request);
                     client_transport.send(&message).await?;
                     let one_way_latency = send_start.elapsed();
                     client_transport.receive().await?;
                     let round_trip_latency = send_start.elapsed();
-                    one_way_latencies.push(one_way_latency);
+                    one_way_latencies.push((one_way_latency, wall_ts));
                     round_trip_latencies.push(round_trip_latency);
                 }
             }
             client_transport.close().await?;
-            Ok::<(Vec<Duration>, Vec<Duration>), anyhow::Error>((
+            Ok::<(Vec<(Duration, u64)>, Vec<Duration>), anyhow::Error>((
                 one_way_latencies,
                 round_trip_latencies,
             ))
         };
 
-        // Execute client work with proper affinity using spawn_with_affinity
+        // Execute client work with proper affinity
         let (one_way_latencies, round_trip_latencies) =
             crate::utils::spawn_with_affinity(client_future, self.config.client_affinity).await?;
 
-        for (i, &one_way_latency) in one_way_latencies.iter().enumerate() {
-            one_way_metrics.record_message(self.config.message_size, Some(one_way_latency))?;
+        for (i, (one_way_latency, wall_ts)) in one_way_latencies.iter().enumerate() {
+            one_way_metrics.record_message(self.config.message_size, Some(*one_way_latency))?;
             if let Some(ref mut manager) = results_manager {
-                // Use current timestamp since latencies are recorded after collection
-                let send_timestamp_ns =
-                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new_combined(
                     i as u64,
                     self.mechanism,
                     self.config.message_size,
-                    one_way_latency,
+                    *one_way_latency,
                     round_trip_latencies[i],
-                    send_timestamp_ns,
+                    *wall_ts,
                 );
                 manager.write_streaming_record_direct(&record).await?;
             }
         }
 
-        for round_trip_latency in round_trip_latencies {
+        for round_trip_latency in &round_trip_latencies {
             round_trip_metrics
-                .record_message(self.config.message_size, Some(round_trip_latency))?;
+                .record_message(self.config.message_size, Some(*round_trip_latency))?;
         }
 
         // --- Cleanup ---
@@ -2633,6 +2655,69 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_parse_latency_file_line_valid() {
+        let (wall, lat) = super::parse_latency_file_line("1700000000000000000,42000").unwrap();
+        assert_eq!(wall, 1_700_000_000_000_000_000);
+        assert_eq!(lat, 42_000);
+    }
+
+    #[test]
+    fn test_parse_latency_file_line_zeros() {
+        let (wall, lat) = super::parse_latency_file_line("0,0").unwrap();
+        assert_eq!(wall, 0);
+        assert_eq!(lat, 0);
+    }
+
+    #[test]
+    fn test_parse_latency_file_line_missing_comma() {
+        let result = super::parse_latency_file_line("123456789");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("wall_send_ns,latency_ns"),
+            "Error should mention expected format, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_parse_latency_file_line_empty() {
+        assert!(super::parse_latency_file_line("").is_err());
+    }
+
+    #[test]
+    fn test_parse_latency_file_line_non_numeric_first() {
+        let result = super::parse_latency_file_line("abc,789");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("wall_send_ns"),
+            "Error should mention wall_send_ns, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_parse_latency_file_line_non_numeric_second() {
+        let result = super::parse_latency_file_line("123,xyz");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("latency_ns"),
+            "Error should mention latency_ns, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_parse_latency_file_line_extra_commas() {
+        // splitn(2, ',') treats "1,2,3" as ["1", "2,3"].
+        // "2,3" is not a valid u64, so this should fail.
+        let result = super::parse_latency_file_line("1,2,3");
+        assert!(result.is_err());
+    }
+
     /// Exercises the one-way streaming path with per-message
     /// streaming enabled (not combined mode), covering the
     /// send_timestamp_ns capture in run_one_way_test.
@@ -2669,8 +2754,10 @@ mod tests {
         let mut rm = crate::results::ResultsManager::new(None, None).unwrap();
         rm.enable_per_message_streaming(&path).unwrap();
 
+        let before_ns = crate::results::MessageLatencyRecord::current_timestamp_ns();
         let res = runner.run(Some(&mut rm)).await;
         assert!(res.is_ok(), "one-way streaming run failed: {:?}", res.err());
+        let after_ns = crate::results::MessageLatencyRecord::current_timestamp_ns();
         rm.finalize().await.unwrap();
 
         let s = std::fs::read_to_string(&path).expect("read streaming file");
@@ -2679,6 +2766,34 @@ mod tests {
             "Streaming output should have headings"
         );
         assert!(s.contains("\"data\""), "Streaming output should have data");
+
+        // Validate that recorded timestamps fall within the
+        // test execution window and are not all identical
+        // (which was the original bug).
+        let parsed: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        let data = parsed["data"].as_array().expect("data should be an array");
+        assert!(!data.is_empty(), "streaming output should contain records");
+        let timestamps: Vec<u64> = data
+            .iter()
+            .map(|row| row[0].as_u64().expect("timestamp_ns"))
+            .collect();
+        for &ts in &timestamps {
+            assert!(
+                ts >= before_ns && ts <= after_ns,
+                "timestamp {} outside test window [{}, {}]",
+                ts,
+                before_ns,
+                after_ns
+            );
+        }
+        if timestamps.len() > 1 {
+            let all_same = timestamps.windows(2).all(|w| w[0] == w[1]);
+            assert!(
+                !all_same,
+                "all timestamps are identical — \
+                 likely still capturing at record-creation time"
+            );
+        }
     }
 
     /// Exercises the round-trip streaming path with per-message
@@ -2717,12 +2832,14 @@ mod tests {
         let mut rm = crate::results::ResultsManager::new(None, None).unwrap();
         rm.enable_per_message_streaming(&path).unwrap();
 
+        let before_ns = crate::results::MessageLatencyRecord::current_timestamp_ns();
         let res = runner.run(Some(&mut rm)).await;
         assert!(
             res.is_ok(),
             "round-trip streaming run failed: {:?}",
             res.err()
         );
+        let after_ns = crate::results::MessageLatencyRecord::current_timestamp_ns();
         rm.finalize().await.unwrap();
 
         let s = std::fs::read_to_string(&path).expect("read streaming file");
@@ -2731,5 +2848,32 @@ mod tests {
             "Streaming output should have headings"
         );
         assert!(s.contains("\"data\""), "Streaming output should have data");
+
+        // Validate that recorded timestamps fall within the
+        // test execution window and are not all identical.
+        let parsed: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        let data = parsed["data"].as_array().expect("data should be an array");
+        assert!(!data.is_empty(), "streaming output should contain records");
+        let timestamps: Vec<u64> = data
+            .iter()
+            .map(|row| row[0].as_u64().expect("timestamp_ns"))
+            .collect();
+        for &ts in &timestamps {
+            assert!(
+                ts >= before_ns && ts <= after_ns,
+                "timestamp {} outside test window [{}, {}]",
+                ts,
+                before_ns,
+                after_ns
+            );
+        }
+        if timestamps.len() > 1 {
+            let all_same = timestamps.windows(2).all(|w| w[0] == w[1]);
+            assert!(
+                !all_same,
+                "all timestamps are identical — \
+                 likely still capturing at record-creation time"
+            );
+        }
     }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1128,12 +1128,16 @@ port={}",
 
             // Stream latency if enabled
             if let Some(ref mut manager) = results_manager {
+                // Use current timestamp since this is server-measured latency read from file
+                let send_timestamp_ns =
+                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new(
                     line_num,
                     self.mechanism,
                     self.config.message_size,
                     crate::metrics::LatencyType::OneWay,
                     latency,
+                    send_timestamp_ns,
                 );
                 manager.stream_latency_record(&record).await?;
             }
@@ -1266,12 +1270,16 @@ port={}",
         for (i, latency) in latencies.iter().enumerate() {
             metrics_collector.record_message(self.config.message_size, Some(*latency))?;
             if let Some(ref mut manager) = results_manager {
+                // Use current timestamp since latencies are recorded after collection
+                let send_timestamp_ns =
+                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new(
                     i as u64,
                     self.mechanism,
                     self.config.message_size,
                     crate::metrics::LatencyType::RoundTrip,
                     *latency,
+                    send_timestamp_ns,
                 );
                 manager.stream_latency_record(&record).await?;
             }
@@ -1558,12 +1566,16 @@ port={}",
         for (i, &one_way_latency) in one_way_latencies.iter().enumerate() {
             one_way_metrics.record_message(self.config.message_size, Some(one_way_latency))?;
             if let Some(ref mut manager) = results_manager {
+                // Use current timestamp since latencies are recorded after collection
+                let send_timestamp_ns =
+                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new_combined(
                     i as u64,
                     self.mechanism,
                     self.config.message_size,
                     one_way_latency,
                     round_trip_latencies[i],
+                    send_timestamp_ns,
                 );
                 manager.write_streaming_record_direct(&record).await?;
             }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -246,6 +246,7 @@ pub struct BenchmarkConfig {
 /// Returns an error if the line does not contain exactly two
 /// comma-separated `u64` values.
 pub fn parse_latency_file_line(line: &str) -> anyhow::Result<(u64, u64)> {
+    let line = line.trim();
     let parts: Vec<&str> = line.splitn(2, ',').collect();
     if parts.len() != 2 {
         anyhow::bail!(

--- a/src/benchmark_blocking.rs
+++ b/src/benchmark_blocking.rs
@@ -1125,27 +1125,22 @@ impl BlockingBenchmarkRunner {
 
         for (i, line) in reader.lines().enumerate() {
             let line = line.context("Failed to read line from latency file")?;
-            let latency_ns: u64 = line
-                .parse()
-                .with_context(|| format!("Failed to parse latency from line: {}", line))?;
+            // Parse "wall_send_ns,latency_ns" format written
+            // by the server process.
+            let (wall_send_ns, latency_ns) = crate::benchmark::parse_latency_file_line(&line)?;
 
             let latency = std::time::Duration::from_nanos(latency_ns);
 
-            // Record in metrics collector
             metrics_collector.record_message(self.config.message_size, Some(latency))?;
 
-            // Stream latency if enabled
             if let Some(ref mut manager) = results_manager {
-                // Use current timestamp since this is server-measured latency read from file
-                let send_timestamp_ns =
-                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new(
                     i as u64,
                     self.mechanism,
                     self.config.message_size,
                     crate::metrics::LatencyType::OneWay,
                     latency,
-                    send_timestamp_ns,
+                    wall_send_ns,
                 );
                 let _ = manager.stream_latency_record(&record);
             }

--- a/src/benchmark_blocking.rs
+++ b/src/benchmark_blocking.rs
@@ -1132,12 +1132,16 @@ impl BlockingBenchmarkRunner {
 
             // Stream latency if enabled
             if let Some(ref mut manager) = results_manager {
+                // Use current timestamp since this is server-measured latency read from file
+                let send_timestamp_ns =
+                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let record = crate::results::MessageLatencyRecord::new(
                     i as u64,
                     self.mechanism,
                     self.config.message_size,
                     crate::metrics::LatencyType::OneWay,
                     latency,
+                    send_timestamp_ns,
                 );
                 let _ = manager.stream_latency_record(&record);
             }
@@ -1226,6 +1230,9 @@ impl BlockingBenchmarkRunner {
             }
 
             while start_time.elapsed() < duration {
+                // Capture send timestamp for streaming record (wall clock)
+                let send_timestamp_ns =
+                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let send_time = Instant::now();
                 let message = Message::new(i, payload.clone(), MessageType::Request);
 
@@ -1245,6 +1252,7 @@ impl BlockingBenchmarkRunner {
                                     self.config.message_size,
                                     crate::metrics::LatencyType::RoundTrip,
                                     latency,
+                                    send_timestamp_ns,
                                 );
                                 let _ = manager.stream_latency_record(&record);
                             }
@@ -1271,6 +1279,9 @@ impl BlockingBenchmarkRunner {
             }
 
             for i in 0..msg_count {
+                // Capture send timestamp for streaming record (wall clock)
+                let send_timestamp_ns =
+                    crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let send_time = Instant::now();
                 let message = Message::new(i as u64, payload.clone(), MessageType::Request);
                 client_transport.send_blocking(&message)?;
@@ -1293,6 +1304,7 @@ impl BlockingBenchmarkRunner {
                             self.config.message_size,
                             crate::metrics::LatencyType::RoundTrip,
                             latency,
+                            send_timestamp_ns,
                         );
                         let _ = manager.stream_latency_record(&record);
                     }

--- a/src/benchmark_blocking.rs
+++ b/src/benchmark_blocking.rs
@@ -694,6 +694,10 @@ impl BlockingBenchmarkRunner {
     ///
     /// ## Test Execution Flow
     ///
+    /// Tests run **sequentially**, not simultaneously. Each test
+    /// spawns its own server process, runs to completion, and tears
+    /// down before the next test starts.
+    ///
     /// 1. **Validation**: Verify core availability and configuration
     /// 2. **Warmup Phase**: Run warmup iterations to stabilize performance
     /// 3. **One-way Testing**: Measure one-way latency if enabled

--- a/src/main.rs
+++ b/src/main.rs
@@ -693,13 +693,13 @@ fn run_server_mode_blocking(args: cli::Args) -> Result<()> {
                 // Calculate actual IPC latency: receive_time - send_time
                 // Use monotonic clock to avoid NTP adjustments affecting measurements
                 let receive_time_ns = get_monotonic_time_ns();
+                let wall_now_ns = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as u64;
                 let latency_ns = receive_time_ns.saturating_sub(message.timestamp);
 
                 if should_buffer_latency(latency_file_path.is_some(), message.id) {
-                    let wall_now_ns = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_nanos() as u64;
                     let wall_send_ns = wall_now_ns.saturating_sub(latency_ns);
                     latency_buffer.push((wall_send_ns, latency_ns));
                 }
@@ -898,13 +898,13 @@ async fn run_server_mode(args: cli::Args) -> Result<()> {
                 // Calculate actual IPC latency: receive_time - send_time
                 // Use monotonic clock to avoid NTP adjustments affecting measurements
                 let receive_time_ns = get_monotonic_time_ns();
+                let wall_now_ns = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as u64;
                 let latency_ns = receive_time_ns.saturating_sub(msg.timestamp);
 
                 if should_buffer_latency(latency_file_path.is_some(), msg.id) {
-                    let wall_now_ns = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_nanos() as u64;
                     let wall_send_ns = wall_now_ns.saturating_sub(latency_ns);
                     latency_buffer.push((wall_send_ns, latency_ns));
                 }
@@ -1016,10 +1016,7 @@ fn should_buffer_latency(latency_file_enabled: bool, message_id: u64) -> bool {
 /// # Errors
 ///
 /// Returns an error if the file cannot be created or written.
-fn write_latency_buffer(
-    path: &str,
-    buffer: &[(u64, u64)],
-) -> Result<()> {
+fn write_latency_buffer(path: &str, buffer: &[(u64, u64)]) -> Result<()> {
     debug!(
         "Writing {} buffered latencies to file: {}",
         buffer.len(),
@@ -1079,18 +1076,12 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let entries: Vec<(u64, u64)> = vec![
-            (1000, 100),
-            (2000, 200),
-            (3000, 999),
-            (0, 0),
-            (5000, 42),
-        ];
+        let entries: Vec<(u64, u64)> =
+            vec![(1000, 100), (2000, 200), (3000, 999), (0, 0), (5000, 42)];
         write_latency_buffer(&path, &entries).unwrap();
 
         let file = std::fs::File::open(&path).unwrap();
-        let lines: Vec<String> =
-            BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+        let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
         assert_eq!(lines.len(), 5);
         assert_eq!(lines[0], "1000,100");
@@ -1145,10 +1136,7 @@ mod tests {
         let file = std::fs::File::open(&path).unwrap();
         let parsed: Vec<(u64, u64)> = BufReader::new(file)
             .lines()
-            .filter_map(|l| {
-                l.ok()
-                    .and_then(|s| parse_latency_file_line(&s).ok())
-            })
+            .filter_map(|l| l.ok().and_then(|s| parse_latency_file_line(&s).ok()))
             .collect();
 
         assert_eq!(parsed, original);

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use ipc_benchmark::{
     results_blocking::BlockingResultsManager,
 };
 use std::io::{self, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, warn};
 
 use tracing_subscriber::{filter::LevelFilter, prelude::*, Layer};
@@ -679,7 +680,7 @@ fn run_server_mode_blocking(args: cli::Args) -> Result<()> {
     // Buffer latencies in memory instead of per-message file I/O
     // This avoids the massive overhead of writing to disk for each message
     let latency_file_path = args.internal_latency_file.clone();
-    let mut latency_buffer: Vec<u64> = if latency_file_path.is_some() {
+    let mut latency_buffer: Vec<(u64, u64)> = if latency_file_path.is_some() {
         Vec::with_capacity(100_000) // Pre-allocate for performance
     } else {
         Vec::new()
@@ -695,7 +696,12 @@ fn run_server_mode_blocking(args: cli::Args) -> Result<()> {
                 let latency_ns = receive_time_ns.saturating_sub(message.timestamp);
 
                 if should_buffer_latency(latency_file_path.is_some(), message.id) {
-                    latency_buffer.push(latency_ns);
+                    let wall_now_ns = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_nanos() as u64;
+                    let wall_send_ns = wall_now_ns.saturating_sub(latency_ns);
+                    latency_buffer.push((wall_send_ns, latency_ns));
                 }
 
                 // Check for shutdown message (used by PMQ and other queue-based transports)
@@ -876,7 +882,7 @@ async fn run_server_mode(args: cli::Args) -> Result<()> {
     // Buffer latencies in memory instead of per-message file I/O
     // This avoids the massive overhead of writing to disk for each message
     let latency_file_path = args.internal_latency_file.clone();
-    let mut latency_buffer: Vec<u64> = if latency_file_path.is_some() {
+    let mut latency_buffer: Vec<(u64, u64)> = if latency_file_path.is_some() {
         Vec::with_capacity(100_000) // Pre-allocate for performance
     } else {
         Vec::new()
@@ -895,7 +901,12 @@ async fn run_server_mode(args: cli::Args) -> Result<()> {
                 let latency_ns = receive_time_ns.saturating_sub(msg.timestamp);
 
                 if should_buffer_latency(latency_file_path.is_some(), msg.id) {
-                    latency_buffer.push(latency_ns);
+                    let wall_now_ns = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_nanos() as u64;
+                    let wall_send_ns = wall_now_ns.saturating_sub(latency_ns);
+                    latency_buffer.push((wall_send_ns, latency_ns));
                 }
 
                 // Message received
@@ -995,14 +1006,20 @@ fn should_buffer_latency(latency_file_enabled: bool, message_id: u64) -> bool {
 
 /// Write a buffer of latency values to a file.
 ///
-/// Each latency is written as a single line containing the
-/// nanosecond value in decimal. This format matches what the
-/// client-side benchmark reader expects.
+/// Each entry is written as a single line containing a
+/// `"wall_send_ns,latency_ns"` pair. `wall_send_ns` is the
+/// approximate wall-clock send time (computed as `wall_now - latency`
+/// on the server) and `latency_ns` is the measured one-way IPC
+/// latency. This format matches what `parse_latency_file_line()`
+/// in the client-side benchmark reader expects.
 ///
 /// # Errors
 ///
 /// Returns an error if the file cannot be created or written.
-fn write_latency_buffer(path: &str, buffer: &[u64]) -> Result<()> {
+fn write_latency_buffer(
+    path: &str,
+    buffer: &[(u64, u64)],
+) -> Result<()> {
     debug!(
         "Writing {} buffered latencies to file: {}",
         buffer.len(),
@@ -1010,8 +1027,8 @@ fn write_latency_buffer(path: &str, buffer: &[u64]) -> Result<()> {
     );
     let mut file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create latency file: {}", path))?;
-    for latency_ns in buffer {
-        writeln!(file, "{}", latency_ns).ok();
+    for &(wall_send_ns, latency_ns) in buffer {
+        writeln!(file, "{},{}", wall_send_ns, latency_ns).ok();
     }
     debug!("Finished writing latencies to file");
     Ok(())
@@ -1051,9 +1068,9 @@ mod tests {
         assert!(!should_buffer_latency(false, u64::MAX));
     }
 
-    /// Verify that write_latency_buffer produces one decimal
-    /// u64 value per line, matching the format that the
-    /// client-side reader expects.
+    /// Verify that write_latency_buffer produces one
+    /// "wall_send_ns,latency_ns" pair per line, matching
+    /// the format that parse_latency_file_line() expects.
     #[test]
     fn test_write_latency_buffer_format() {
         let dir = std::env::temp_dir();
@@ -1062,18 +1079,25 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let latencies: Vec<u64> = vec![100, 200, 999, 0, 42];
-        write_latency_buffer(&path, &latencies).unwrap();
+        let entries: Vec<(u64, u64)> = vec![
+            (1000, 100),
+            (2000, 200),
+            (3000, 999),
+            (0, 0),
+            (5000, 42),
+        ];
+        write_latency_buffer(&path, &entries).unwrap();
 
         let file = std::fs::File::open(&path).unwrap();
-        let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+        let lines: Vec<String> =
+            BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
         assert_eq!(lines.len(), 5);
-        assert_eq!(lines[0], "100");
-        assert_eq!(lines[1], "200");
-        assert_eq!(lines[2], "999");
-        assert_eq!(lines[3], "0");
-        assert_eq!(lines[4], "42");
+        assert_eq!(lines[0], "1000,100");
+        assert_eq!(lines[1], "2000,200");
+        assert_eq!(lines[2], "3000,999");
+        assert_eq!(lines[3], "0,0");
+        assert_eq!(lines[4], "5000,42");
 
         let _ = std::fs::remove_file(&path);
     }
@@ -1102,19 +1126,29 @@ mod tests {
     /// matching the same parse logic the benchmark reader uses.
     #[test]
     fn test_write_latency_buffer_round_trip_parse() {
+        use ipc_benchmark::benchmark::parse_latency_file_line;
+
         let dir = std::env::temp_dir();
         let path = dir
             .join("test_latency_buffer_roundtrip.txt")
             .to_string_lossy()
             .to_string();
 
-        let original: Vec<u64> = vec![1, u64::MAX - 1, 0, 123_456_789];
+        let original: Vec<(u64, u64)> = vec![
+            (1, 1),
+            (u64::MAX - 1, u64::MAX - 1),
+            (0, 0),
+            (999_999_999, 123_456_789),
+        ];
         write_latency_buffer(&path, &original).unwrap();
 
         let file = std::fs::File::open(&path).unwrap();
-        let parsed: Vec<u64> = BufReader::new(file)
+        let parsed: Vec<(u64, u64)> = BufReader::new(file)
             .lines()
-            .filter_map(|l| l.ok().and_then(|s| s.trim().parse::<u64>().ok()))
+            .filter_map(|l| {
+                l.ok()
+                    .and_then(|s| parse_latency_file_line(&s).ok())
+            })
             .collect();
 
         assert_eq!(parsed, original);
@@ -1126,7 +1160,10 @@ mod tests {
     /// an invalid path (e.g. a non-existent directory).
     #[test]
     fn test_write_latency_buffer_invalid_path() {
-        let result = write_latency_buffer("/no/such/directory/latencies.txt", &[1, 2, 3]);
+        let result = write_latency_buffer(
+            "/no/such/directory/latencies.txt",
+            &[(1000, 1), (2000, 2), (3000, 3)],
+        );
         assert!(result.is_err(), "writing to invalid path should fail");
     }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -2454,4 +2454,63 @@ mod tests {
         assert_eq!(results.test_config.concurrency, 2);
         assert_eq!(results.test_config.message_size, 512);
     }
+
+    /// Verify that `MessageLatencyRecord::new()` uses the
+    /// caller-provided `send_timestamp_ns` instead of capturing
+    /// `SystemTime::now()` internally.
+    #[test]
+    fn test_new_uses_provided_send_timestamp() {
+        let fixed_ts: u64 = 1_700_000_000_000_000_000;
+        let record = MessageLatencyRecord::new(
+            42,
+            IpcMechanism::TcpSocket,
+            1024,
+            LatencyType::OneWay,
+            Duration::from_micros(100),
+            fixed_ts,
+        );
+        assert_eq!(
+            record.timestamp_ns, fixed_ts,
+            "timestamp_ns should match the provided value"
+        );
+    }
+
+    /// Verify that `MessageLatencyRecord::new_combined()` uses the
+    /// caller-provided `send_timestamp_ns`.
+    #[test]
+    fn test_new_combined_uses_provided_send_timestamp() {
+        let fixed_ts: u64 = 1_600_000_000_000_000_000;
+        let record = MessageLatencyRecord::new_combined(
+            7,
+            IpcMechanism::SharedMemory,
+            512,
+            Duration::from_micros(50),
+            Duration::from_micros(120),
+            fixed_ts,
+        );
+        assert_eq!(
+            record.timestamp_ns, fixed_ts,
+            "timestamp_ns should match the provided value"
+        );
+    }
+
+    /// Verify that `current_timestamp_ns()` returns a plausible,
+    /// monotonically non-decreasing wall-clock timestamp.
+    #[test]
+    fn test_current_timestamp_ns_returns_recent_value() {
+        let before = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let ts = MessageLatencyRecord::current_timestamp_ns();
+        let after = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        assert!(
+            ts >= before && ts <= after,
+            "current_timestamp_ns should be between              before ({}) and after ({}), got {}",
+            before, after, ts
+        );
+    }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -153,21 +153,18 @@ impl MessageLatencyRecord {
     /// - `message_size`: Size of the message payload
     /// - `latency_type`: Type of latency measurement
     /// - `latency`: Measured latency duration
+    /// - `send_timestamp_ns`: Unix timestamp (nanoseconds) when the message was sent
     ///
     /// ## Returns
-    /// New record with current system timestamp
+    /// New record with the provided send timestamp
     pub fn new(
         message_id: u64,
         mechanism: IpcMechanism,
         message_size: usize,
         latency_type: LatencyType,
         latency: Duration,
+        send_timestamp_ns: u64,
     ) -> Self {
-        let timestamp_ns = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
-
         let latency_ns = latency.as_nanos() as u64;
         let (one_way_latency_ns, round_trip_latency_ns) = match latency_type {
             LatencyType::OneWay => (Some(latency_ns), None),
@@ -175,7 +172,7 @@ impl MessageLatencyRecord {
         };
 
         Self {
-            timestamp_ns,
+            timestamp_ns: send_timestamp_ns,
             message_id,
             mechanism,
             message_size,
@@ -192,23 +189,20 @@ impl MessageLatencyRecord {
     /// - `message_size`: Size of the message payload
     /// - `one_way_latency`: One-way latency measurement
     /// - `round_trip_latency`: Round-trip latency measurement
+    /// - `send_timestamp_ns`: Unix timestamp (nanoseconds) when the message was sent
     ///
     /// ## Returns
-    /// New record with both latency measurements and current timestamp
+    /// New record with both latency measurements and the provided send timestamp
     pub fn new_combined(
         message_id: u64,
         mechanism: IpcMechanism,
         message_size: usize,
         one_way_latency: Duration,
         round_trip_latency: Duration,
+        send_timestamp_ns: u64,
     ) -> Self {
-        let timestamp_ns = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos() as u64;
-
         Self {
-            timestamp_ns,
+            timestamp_ns: send_timestamp_ns,
             message_id,
             mechanism,
             message_size,
@@ -239,6 +233,21 @@ impl MessageLatencyRecord {
     /// Check if the record contains combined latency data (both one-way and round-trip)
     pub fn is_combined(&self) -> bool {
         self.one_way_latency_ns.is_some() && self.round_trip_latency_ns.is_some()
+    }
+
+    /// Get current Unix timestamp in nanoseconds
+    ///
+    /// Helper function to capture the current time as a Unix timestamp
+    /// for use with `new()` and `new_combined()` methods.
+    ///
+    /// ## Returns
+    /// Unix timestamp in nanoseconds since epoch
+    #[inline]
+    pub fn current_timestamp_ns() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64
     }
 }
 
@@ -1942,6 +1951,7 @@ mod tests {
         let mut mgr = ResultsManager::new(None, None).unwrap();
         mgr.enable_per_message_streaming(&path).unwrap();
 
+        let timestamp = MessageLatencyRecord::current_timestamp_ns();
         #[cfg(unix)]
         let r1 = MessageLatencyRecord::new(
             1,
@@ -1949,6 +1959,7 @@ mod tests {
             128,
             LatencyType::OneWay,
             Duration::from_micros(10),
+            timestamp,
         );
         #[cfg(not(unix))]
         let r1 = MessageLatencyRecord::new(
@@ -1957,6 +1968,7 @@ mod tests {
             128,
             LatencyType::OneWay,
             Duration::from_micros(10),
+            timestamp,
         );
         #[cfg(unix)]
         let r2 = MessageLatencyRecord::new(
@@ -1965,6 +1977,7 @@ mod tests {
             128,
             LatencyType::RoundTrip,
             Duration::from_micros(20),
+            timestamp,
         );
         #[cfg(not(unix))]
         let r2 = MessageLatencyRecord::new(
@@ -1973,6 +1986,7 @@ mod tests {
             128,
             LatencyType::RoundTrip,
             Duration::from_micros(20),
+            timestamp,
         );
 
         let rt = Runtime::new().unwrap();
@@ -2002,6 +2016,7 @@ mod tests {
         mgr.both_tests_enabled = true;
 
         // Insert pending records out-of-order.
+        let timestamp = MessageLatencyRecord::current_timestamp_ns();
         #[cfg(unix)]
         let r_high = MessageLatencyRecord::new(
             5,
@@ -2009,6 +2024,7 @@ mod tests {
             128,
             LatencyType::OneWay,
             Duration::from_micros(50),
+            timestamp,
         );
         #[cfg(not(unix))]
         let r_high = MessageLatencyRecord::new(
@@ -2017,6 +2033,7 @@ mod tests {
             128,
             LatencyType::OneWay,
             Duration::from_micros(50),
+            timestamp,
         );
         #[cfg(unix)]
         let r_low = MessageLatencyRecord::new(
@@ -2025,6 +2042,7 @@ mod tests {
             128,
             LatencyType::OneWay,
             Duration::from_micros(20),
+            timestamp,
         );
         #[cfg(not(unix))]
         let r_low = MessageLatencyRecord::new(
@@ -2033,6 +2051,7 @@ mod tests {
             128,
             LatencyType::OneWay,
             Duration::from_micros(20),
+            timestamp,
         );
 
         mgr.pending_records.insert(r_high.message_id, r_high);
@@ -2071,6 +2090,7 @@ mod tests {
         let mut mgr = ResultsManager::new(None, None).unwrap();
         mgr.enable_csv_streaming(&path).unwrap();
 
+        let timestamp = MessageLatencyRecord::current_timestamp_ns();
         #[cfg(unix)]
         let r1 = MessageLatencyRecord::new(
             1,
@@ -2078,6 +2098,7 @@ mod tests {
             64,
             LatencyType::OneWay,
             Duration::from_micros(5),
+            timestamp,
         );
         #[cfg(not(unix))]
         let r1 = MessageLatencyRecord::new(
@@ -2086,6 +2107,7 @@ mod tests {
             64,
             LatencyType::OneWay,
             Duration::from_micros(5),
+            timestamp,
         );
 
         let rt = Runtime::new().unwrap();
@@ -2272,12 +2294,14 @@ mod tests {
 
     #[test]
     fn test_message_latency_record_new_combined() {
+        let timestamp = MessageLatencyRecord::current_timestamp_ns();
         let record = MessageLatencyRecord::new_combined(
             42,
             IpcMechanism::TcpSocket,
             256,
             Duration::from_micros(100),
             Duration::from_micros(200),
+            timestamp,
         );
 
         assert_eq!(record.message_id, 42);
@@ -2286,7 +2310,7 @@ mod tests {
         assert_eq!(record.one_way_latency_ns, Some(100_000)); // 100 micros = 100,000 ns
         assert_eq!(record.round_trip_latency_ns, Some(200_000));
         assert!(record.is_combined());
-        assert!(record.timestamp_ns > 0);
+        assert_eq!(record.timestamp_ns, timestamp);
     }
 
     #[test]

--- a/utils/dashboard/README.md
+++ b/utils/dashboard/README.md
@@ -71,7 +71,7 @@ For complete ipc-benchmark parameter documentation, see the [main README](../../
 - **Performance Overview**: AI-generated insights and key metrics cards
 - **Head-to-Head Comparisons**: Interactive comparison matrices for P50/Max latency
 - **Statistical Analysis**: Comprehensive latency and throughput breakdowns
-- **Data Tables**: Sortable pivot tables for one-way vs round-trip performance
+- **Data Tables**: Sortable pivot tables for one-way vs round-trip performance (these tests run sequentially, not simultaneously)
 
 ### **Time Series Analysis** 
 - **Interactive Visualizations**: Real-time scatter plots with advanced controls


### PR DESCRIPTION
<!-- 
Thank you for your contribution!
Please review our [Contributing Guidelines](CONTRIBUTING.md) for details on our development process, coding style, and testing.
-->

## Description
Brief description of changes

## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ x] Tests pass locally
- [ x] Added tests for new functionality
- [ x] Updated documentation

## Checklist
- [ x] Code follows style guidelines
- [ x] Self-review completed
- [ ] Comments added for complex code
- [ x] Documentation updated
- [ ] No breaking changes (or marked as breaking)

# PR: Fix Streaming Output Timestamps Across All Code Paths

## Summary

Streaming output timestamps (`timestamp_ns` in JSON/CSV per-message
records) were inaccurate across multiple code paths. Instead of
recording when each message was actually sent, timestamps were captured
at record-creation time — either post-test during batch iteration or
at file-read time. This caused all timestamps within a test run to
cluster into the same second, making time-series analysis of streaming
data meaningless.

Because this tool's primary purpose is precision measurement, incorrect
timestamps in the streaming output undermine the validity of per-message
latency records for any downstream analysis or visualization.

**Branch:** `fix/streaming-timestamps`
**Base:** `main`
**Files changed:** 11 (496 insertions, 60 deletions)

---

## Root Cause

Commit `e0ff7fa` (Oct 8, 2025, PR #82) refactored the benchmark runner
to collect latencies inside spawned async futures, then batch-create
`MessageLatencyRecord` objects after the futures completed. This moved
the `SystemTime::now()` call from inside the hot loop (where it
reflected each message's send time) to the post-test iteration (where
it reflected the moment the record was created — all within the same
second).

The initial fix on this branch (`68afe07`) changed the
`MessageLatencyRecord` API to accept `send_timestamp_ns` as a
parameter, but only the blocking round-trip path was actually capturing
timestamps at send time. Three other code path families remained broken.

---

## Problems and Fixes

### 1. Async round-trip timestamps captured post-test

**Problem:** The client future returned `Vec<Duration>`. After the
future completed, the post-test loop called `current_timestamp_ns()`
at record-creation time. All records received the same timestamp.

**Fix:** Changed the future to capture `current_timestamp_ns()` before
each `send()` and return `Vec<(Duration, u64)>`. The post-test loop
uses the captured timestamp.

```rust
// Inside the client future, before each send:
let wall_ts = MessageLatencyRecord::current_timestamp_ns();
let send_time = Instant::now();
client_transport.send(&message).await?;
// ...
latencies.push((send_time.elapsed(), wall_ts));

// Post-test loop:
for (i, (latency, wall_ts)) in latencies.iter().enumerate() {
    let record = MessageLatencyRecord::new(
        i as u64, mechanism, msg_size,
        LatencyType::RoundTrip, *latency, *wall_ts,
    );
}
```

**Applies to:** Both duration-based and count-based async round-trip
loops in `src/benchmark.rs`.

### 2. Async combined timestamps captured post-test

**Problem:** Same pattern as round-trip — the combined test (one-way +
round-trip in a single run) collected latency durations inside the
spawned future and created records post-test with stale timestamps.

**Fix:** Changed `one_way_latencies` to `Vec<(Duration, u64)>` to
carry the wall-clock timestamp alongside each measurement. The
timestamp is captured before each `send()` inside the future.

**Applies to:** Both duration-based and count-based async combined
loops in `src/benchmark.rs`.

### 3. One-way timestamps from file-read time instead of send time

**Problem:** One-way tests use a server process that measures receive
latency and writes results to a temporary file. The original format
was one `latency_ns` value per line. The client read this file
post-test and called `current_timestamp_ns()` at file-read time —
all records received the same timestamp.

**Fix (server side):** Both async and blocking server loops now write
`wall_send_ns,latency_ns` per line. The wall-clock send time is
computed as `SystemTime::now() - latency_ns`, approximating when the
message entered the IPC channel.

```rust
// Server, after measuring latency:
let wall_now_ns = SystemTime::now()
    .duration_since(UNIX_EPOCH)
    .unwrap_or_default()
    .as_nanos() as u64;
let wall_send_ns = wall_now_ns.saturating_sub(latency_ns);
writeln!(file, "{},{}", wall_send_ns, latency_ns).ok();
```

**Fix (client side):** A new `parse_latency_file_line()` function
parses the two-field format. Both async and blocking file readers
use the parsed `wall_send_ns` as `send_timestamp_ns`.

**Applies to:** `src/main.rs` (both server loops), `src/benchmark.rs`
(async reader), `src/benchmark_blocking.rs` (blocking reader).

---

## Known Limitations

### Wall-clock / monotonic clock mixing in one-way path

For one-way tests, the server computes the send timestamp by
subtracting the measured monotonic latency from its current wall-clock
time. This mixes two clock domains:

- `latency_ns` = `monotonic_receive - monotonic_send`
  (from message timestamp)
- `wall_send_ns` = `SystemTime::now() - latency_ns`

If NTP adjusts the system clock between message send and receive, the
computed `wall_send_ns` will be slightly off. This is the best
approximation available without clock synchronization between the
client and server processes. The error is bounded by the magnitude
of any NTP adjustment during the test (typically microseconds).

### Timestamp capture ordering

In the round-trip and combined futures, `current_timestamp_ns()` is
captured one instruction before `Instant::now()`. The wall-clock
timestamp therefore slightly predates the monotonic measurement start.
The gap is single-digit nanoseconds — orders of magnitude below the
IPC latencies being measured.

---

## Tests Added

### Unit tests for `parse_latency_file_line` (7 tests)

| Test | Coverage |
|------|----------|
| `test_parse_latency_file_line_valid` | Happy path: `"170...,42000"` |
| `test_parse_latency_file_line_zeros` | Edge case: `"0,0"` |
| `test_parse_latency_file_line_missing_comma` | Error: single value |
| `test_parse_latency_file_line_empty` | Error: empty string |
| `test_parse_latency_file_line_non_numeric_first` | Error: `"abc,789"` |
| `test_parse_latency_file_line_non_numeric_second` | Error: `"123,xyz"` |
| `test_parse_latency_file_line_extra_commas` | Error: `"1,2,3"` |

### Enhanced end-to-end streaming tests (2 tests)

Both `test_one_way_streaming_captures_send_timestamp` and
`test_round_trip_streaming_captures_send_timestamp` now validate:

1. All `timestamp_ns` values fall within the test execution window
   (`before_ns <= ts <= after_ns`)
2. Timestamps are **not all identical** (which was the original bug)

### Pre-existing timestamp API tests (3 tests in `results.rs`)

- `test_new_uses_provided_send_timestamp`
- `test_new_combined_uses_provided_send_timestamp`
- `test_current_timestamp_ns_returns_recent_value`

---

## Documentation Added

### README.md: Streaming Output Columns

Added a new "Streaming Output Columns" section documenting all six
per-message streaming columns with types, descriptions, and nullable
semantics:

| Column | Type | Description |
|--------|------|-------------|
| `timestamp_ns` | `u64` | Wall-clock time message was sent |
| `message_id` | `u64` | Zero-based message identifier |
| `mechanism` | `string` | IPC mechanism name |
| `message_size` | `u64` | Payload size in bytes |
| `one_way_latency_ns` | `u64`/`null` | One-way latency |
| `round_trip_latency_ns` | `u64`/`null` | Round-trip latency |

Includes a note on `timestamp_ns` accuracy for one-way tests
(wall-clock / monotonic clock mixing).

---

## Validation

### Unit and Integration Tests

```
$ cargo test
test result: ok. 265 passed; 0 failed; 1 ignored
(+ 42 doc tests, 27 integration tests — 334 total)

$ cargo clippy --all-targets -- -D warnings
# zero warnings

$ cargo fmt --check
# clean

$ scripts/msrv-check.sh
[MSRV] Rust 1.70 build/tests passed.
```

### Functional Verification

3-second duration benchmarks across all mechanisms with streaming
output enabled. Timestamps validated to span the full test window:

| Mechanism | Mode | First Timestamp | Last Timestamp | Delta (s) | Messages |
|-----------|------|----------------|---------------|-----------|----------|
| UDS | Round-Trip | 13:13:48.101628 | 13:13:51.101572 | 3.000 | 213,424 |
| TCP | Round-Trip | 13:13:55.154037 | 13:13:58.153894 | 3.000 | 132,423 |
| SHM | One-Way | 13:17:32.079542 | 13:17:35.079503 | 3.000 | 1,317,468 |
| PMQ | Round-Trip | 13:14:15.407160 | 13:14:18.362355 | 2.955 | 42,687 |

All mechanisms show timestamps distributed across the full test
duration. PMQ delta is 45ms short due to backpressure from shallow
system queue depth (typically 10 messages).

### Before/After: Timestamp Distribution

**Before fix (main branch):** All `timestamp_ns` values in streaming
output were within the same second, regardless of test duration. A
3-second test with 200,000+ messages would show all timestamps
clustering around a single epoch second.

**After fix:** Timestamps span the full test duration. Each message's
`timestamp_ns` reflects the approximate wall-clock time it was sent,
enabling meaningful time-series analysis of per-message latency data.

---

## Files Changed

| File | Change |
|------|--------|
| `src/benchmark.rs` | Capture `wall_ts` inside async round-trip and combined futures before each `send()`; update one-way file reader to parse new `wall_send_ns,latency_ns` format; add `parse_latency_file_line()` with 7 unit tests; enhance 2 end-to-end streaming tests with timestamp validation |
| `src/benchmark_blocking.rs` | Update blocking one-way file reader to parse new format using `parse_latency_file_line()` |
| `src/main.rs` | Both async and blocking server loops write `wall_send_ns,latency_ns` per line (was `latency_ns` only) |
| `README.md` | Add "Streaming Output Columns" section with column definitions and accuracy note |
| `src/results.rs` | `MessageLatencyRecord::new()` and `new_combined()` accept `send_timestamp_ns` parameter; add `current_timestamp_ns()` helper; 3 API tests |
| `src/ipc/tcp_socket.rs` | Refactor `is_some()/unwrap()` to `if let` (clippy fix) |
| `src/ipc/unix_domain_socket.rs` | Same clippy fix |
| `Cargo.toml` | Pin uuid to `<1.21` for MSRV compatibility |
| `.cargo/audit.toml` | Ignore known MSRV-pinned dependency advisories |
| `CONFIG.md` | Document sequential test execution |
| `utils/dashboard/README.md` | Note sequential test execution |

---

## Risk Assessment

- **Low risk.** The core latency measurement logic (monotonic clock,
  `get_monotonic_time_ns()`) is untouched. Only the wall-clock
  metadata timestamp in streaming records is changed.
- **Backward compatible.** No CLI changes. Streaming output JSON/CSV
  schema is unchanged (same columns, same types). The internal
  server-to-client latency file format changed from `latency_ns` to
  `wall_send_ns,latency_ns`, but this file is ephemeral (created and
  deleted within a single benchmark run) and never exposed to users.
- **All 334 tests pass** with zero clippy warnings.
- **MSRV 1.70 verified** via containerized pre-commit check.

