### PR TITLE
fix: Check pthread_mutex_init/condattr_init return values in SHM-direct

### DIFF
--- a/src/ipc/shared_memory_direct.rs
+++ b/src/ipc/shared_memory_direct.rs
@@ -183,23 +183,57 @@ impl RawSharedMessage {
 
         // Initialize mutex attributes with PTHREAD_PROCESS_SHARED
         let mut mutex_attr = MaybeUninit::uninit();
-        libc::pthread_mutexattr_init(mutex_attr.as_mut_ptr());
-        libc::pthread_mutexattr_setpshared(mutex_attr.as_mut_ptr(), libc::PTHREAD_PROCESS_SHARED);
+        let ret = libc::pthread_mutexattr_init(mutex_attr.as_mut_ptr());
+        if ret != 0 {
+            return Err(anyhow!("pthread_mutexattr_init failed with errno {}", ret));
+        }
+        let ret = libc::pthread_mutexattr_setpshared(
+            mutex_attr.as_mut_ptr(),
+            libc::PTHREAD_PROCESS_SHARED,
+        );
+        if ret != 0 {
+            libc::pthread_mutexattr_destroy(mutex_attr.as_mut_ptr());
+            return Err(anyhow!(
+                "pthread_mutexattr_setpshared failed with errno {}",
+                ret
+            ));
+        }
 
-        // Initialize the mutex
+        // Initialize the mutex with process-shared attribute
         let mut mutex = MaybeUninit::uninit();
-        libc::pthread_mutex_init(mutex.as_mut_ptr(), mutex_attr.as_ptr());
+        let ret = libc::pthread_mutex_init(mutex.as_mut_ptr(), mutex_attr.as_ptr());
         libc::pthread_mutexattr_destroy(mutex_attr.as_mut_ptr());
+        if ret != 0 {
+            return Err(anyhow!("pthread_mutex_init failed with errno {}", ret));
+        }
         self.mutex = mutex.assume_init();
 
-        // Initialize condition variable with PTHREAD_PROCESS_SHARED
+        // Initialize condition variable attributes with PTHREAD_PROCESS_SHARED
         let mut cond_attr = MaybeUninit::uninit();
-        libc::pthread_condattr_init(cond_attr.as_mut_ptr());
-        libc::pthread_condattr_setpshared(cond_attr.as_mut_ptr(), libc::PTHREAD_PROCESS_SHARED);
+        let ret = libc::pthread_condattr_init(cond_attr.as_mut_ptr());
+        if ret != 0 {
+            libc::pthread_mutex_destroy(&mut self.mutex);
+            return Err(anyhow!("pthread_condattr_init failed with errno {}", ret));
+        }
+        let ret =
+            libc::pthread_condattr_setpshared(cond_attr.as_mut_ptr(), libc::PTHREAD_PROCESS_SHARED);
+        if ret != 0 {
+            libc::pthread_condattr_destroy(cond_attr.as_mut_ptr());
+            libc::pthread_mutex_destroy(&mut self.mutex);
+            return Err(anyhow!(
+                "pthread_condattr_setpshared failed with errno {}",
+                ret
+            ));
+        }
 
+        // Initialize the condition variable with process-shared attribute
         let mut cond = MaybeUninit::uninit();
-        libc::pthread_cond_init(cond.as_mut_ptr(), cond_attr.as_ptr());
+        let ret = libc::pthread_cond_init(cond.as_mut_ptr(), cond_attr.as_ptr());
         libc::pthread_condattr_destroy(cond_attr.as_mut_ptr());
+        if ret != 0 {
+            libc::pthread_mutex_destroy(&mut self.mutex);
+            return Err(anyhow!("pthread_cond_init failed with errno {}", ret));
+        }
         self.cond = cond.assume_init();
 
         // Initialize coordination flags and payload length


### PR DESCRIPTION
## Summary

- Add return value checking to all 6 pthread initialization calls in `RawSharedMessage::init()`
- Proper cleanup of already-initialized primitives on failure (e.g., destroys mutex if condattr_init fails)
- Returns informative error messages with the failing errno

## Context

The `init()` function called pthread_mutexattr_init, pthread_mutexattr_setpshared, pthread_mutex_init, pthread_condattr_init, pthread_condattr_setpshared, and pthread_cond_init without checking return values. On failure (e.g., resource exhaustion), this would silently produce uninitialized synchronization primitives, leading to undefined behavior.

Fixes #131

## Test plan

- [x] All existing SHM-direct tests pass (13 tests)
- [x] Full test suite passes (476 tests)
- [x] clippy clean, fmt clean, MSRV check passes

Made with [Cursor](https://cursor.com)