### PR TITLE
fix: Check server process exit status after wait()

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -624,9 +624,15 @@ impl BenchmarkRunner {
 
         // --- Cleanup ---
         client_transport.close().await?;
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error during warmup")?;
+            .context("Failed to wait for server process during warmup")?;
+        if !status.success() {
+            warn!(
+                "Server process exited with non-zero status during warmup: {}",
+                status
+            );
+        }
 
         debug!("Warmup completed");
         Ok(())
@@ -1127,9 +1133,12 @@ port={}",
         crate::utils::spawn_with_affinity(client_future, self.config.client_affinity).await?;
 
         // --- Cleanup ---
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error")?;
+            .context("Failed to wait for server process")?;
+        if !status.success() {
+            warn!("Server process exited with non-zero status: {}", status);
+        }
 
         // --- Read server-measured latencies from file ---
         debug!(
@@ -1312,9 +1321,12 @@ port={}",
         }
 
         // --- Cleanup ---
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error")?;
+            .context("Failed to wait for server process")?;
+        if !status.success() {
+            warn!("Server process exited with non-zero status: {}", status);
+        }
         Ok(())
     }
 
@@ -1612,9 +1624,12 @@ port={}",
         }
 
         // --- Cleanup ---
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error")?;
+            .context("Failed to wait for server process")?;
+        if !status.success() {
+            warn!("Server process exited with non-zero status: {}", status);
+        }
         Ok(())
     }
 

--- a/src/benchmark_blocking.rs
+++ b/src/benchmark_blocking.rs
@@ -868,9 +868,15 @@ impl BlockingBenchmarkRunner {
         }
 
         client_transport.close_blocking()?;
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error during warmup")?;
+            .context("Failed to wait for server process during warmup")?;
+        if !status.success() {
+            warn!(
+                "Server process exited with non-zero status during warmup: {}",
+                status
+            );
+        }
 
         debug!("Warmup completed");
         Ok(())
@@ -1122,9 +1128,12 @@ impl BlockingBenchmarkRunner {
         }
 
         client_transport.close_blocking()?;
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error")?;
+            .context("Failed to wait for server process")?;
+        if !status.success() {
+            warn!("Server process exited with non-zero status: {}", status);
+        }
 
         // --- Read server-measured latencies from file ---
         debug!(
@@ -1348,9 +1357,12 @@ impl BlockingBenchmarkRunner {
         }
 
         client_transport.close_blocking()?;
-        server_process
+        let status = server_process
             .wait()
-            .context("Server process exited with an error")?;
+            .context("Failed to wait for server process")?;
+        if !status.success() {
+            warn!("Server process exited with non-zero status: {}", status);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- All 7 `server_process.wait()` call sites now capture and check `ExitStatus`
- Emits a warning if the server exited with non-zero status
- Uses `warn!` rather than `Err` to avoid discarding valid results when the server completed work before abnormal exit

## Context

Previously, `.wait()` only propagated errors from the wait syscall itself (very rare). If the server crashed with exit code 1, the `ExitStatus` was silently discarded — making server failures invisible during benchmark runs.

Fixes #129

## Test plan

- [x] Full test suite passes (476 tests)
- [x] clippy clean, fmt clean, MSRV check passes

Made with [Cursor](https://cursor.com)