### PR TITLE
fix: Blocking round-trip now respects include_first_message flag

### DIFF
--- a/src/benchmark_blocking.rs
+++ b/src/benchmark_blocking.rs
@@ -1291,19 +1291,17 @@ impl BlockingBenchmarkRunner {
                 }
             }
         } else {
-            // Message-count based test
+            // Message-count based test — match the async runner's
+            // skip-first-message logic: send one extra iteration and
+            // discard its latency rather than using a canary message.
             let msg_count = self.config.msg_count.unwrap_or_default();
+            let iterations = if self.config.include_first_message {
+                msg_count
+            } else {
+                msg_count + 1
+            };
 
-            // Send canary message if first message should not be included
-            if !self.config.include_first_message {
-                let canary = Message::new(u64::MAX, payload.clone(), MessageType::Request);
-                if client_transport.send_blocking(&canary).is_ok() {
-                    let _ = client_transport.receive_blocking();
-                }
-            }
-
-            for i in 0..msg_count {
-                // Capture send timestamp for streaming record (wall clock)
+            for i in 0..iterations {
                 let send_timestamp_ns =
                     crate::results::MessageLatencyRecord::current_timestamp_ns();
                 let send_time = Instant::now();
@@ -1318,9 +1316,7 @@ impl BlockingBenchmarkRunner {
 
                 let latency = send_time.elapsed();
 
-                // Record latency for all measured messages
-                if true {
-                    // Stream latency if enabled
+                if i > 0 || self.config.include_first_message {
                     if let Some(ref mut manager) = results_manager {
                         let record = crate::results::MessageLatencyRecord::new(
                             i as u64,
@@ -1333,7 +1329,6 @@ impl BlockingBenchmarkRunner {
                         let _ = manager.stream_latency_record(&record);
                     }
 
-                    // Record in metrics collector
                     metrics_collector.record_message(self.config.message_size, Some(latency))?;
                 }
             }


### PR DESCRIPTION
## Summary

- Port the async runner's skip-first-message logic to blocking round-trip message-count path
- Send `msg_count + 1` iterations and discard first latency (matching async behavior)
- Remove the canary-based approach which didn't guarantee equivalent warm-path conditions
- Remove dead `if true { ... }` scaffolding

## Context

The blocking round-trip used a canary approach (separate warmup message before the loop) but then recorded ALL messages. The async runner correctly sends `msg_count + 1` and skips recording `i == 0`, ensuring the discarded message experiences identical conditions to measured messages. This commit brings the blocking runner to parity.

Fixes #122

## Test plan

- [x] Full test suite passes (476 tests)
- [x] clippy clean, fmt clean, MSRV check passes

Made with [Cursor](https://cursor.com)