### PR TITLE
fix: Forward duration flag to spawned server in blocking runner

### DIFF
--- a/src/benchmark_blocking.rs
+++ b/src/benchmark_blocking.rs
@@ -439,10 +439,16 @@ impl BlockingBenchmarkRunner {
         cmd.arg("-m")
             .arg(self.mechanism.to_possible_value().unwrap().get_name());
 
-        // Add message size and count
+        // Add message size
         cmd.arg("--message-size")
             .arg(self.config.message_size.to_string());
-        cmd.arg("--msg-count").arg(self.get_msg_count().to_string());
+
+        // Forward duration or msg-count (duration takes precedence)
+        if let Some(duration) = self.config.duration {
+            cmd.arg("-d").arg(format!("{}s", duration.as_secs_f64()));
+        } else if let Some(count) = self.config.msg_count {
+            cmd.arg("--msg-count").arg(count.to_string());
+        }
 
         // Add transport-specific identifiers
         if !transport_config.socket_path.is_empty() {


### PR DESCRIPTION
## Summary

- Replace unconditional `--msg-count` with conditional duration/msg-count forwarding
- If `config.duration` is set, pass `-d <seconds>` to the server
- Otherwise if `config.msg_count` is set, pass `--msg-count <count>`

## Context

The blocking runner always passed `--msg-count 0` to the spawned server in duration mode (since `get_msg_count()` returns 0 when duration is set). This caused server/client config divergence — the server would attempt a 0-message run while the client ran for the specified duration. Now mirrors the async runner's logic.

Fixes #121

## Test plan

- [x] Full test suite passes (476 tests)
- [x] clippy clean, fmt clean, MSRV check passes

Made with [Cursor](https://cursor.com)