### PR TITLE
fix: Forward missing CLI flags to spawned server in async runner

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -821,9 +821,37 @@ impl BenchmarkRunner {
             IpcMechanism::All => {} // 'All' is expanded in the main process
         }
 
+        // Forward buffer size so server uses the same transport config
+        cmd.arg("--buffer-size")
+            .arg(transport_config.buffer_size.to_string());
+
+        // Forward --shm-direct flag if enabled
+        if self.args.shm_direct {
+            cmd.arg("--shm-direct");
+        }
+
+        // Forward PMQ priority if applicable
+        #[cfg(target_os = "linux")]
+        if self.mechanism == IpcMechanism::PosixMessageQueue {
+            cmd.arg("--pmq-priority")
+                .arg(self.config.pmq_priority.to_string());
+        }
+
+        // Forward send-delay so server can enable precise timestamps
+        if let Some(delay) = self.config.send_delay {
+            let micros = delay.as_micros();
+            cmd.arg("--send-delay").arg(format!("{micros}us"));
+        }
+
         // Add latency file path if provided (for true IPC measurement)
         if let Some(path) = latency_file_path {
             cmd.arg("--internal-latency-file").arg(path);
+        }
+
+        // Forward verbose flags to the server for debugging
+        let verbose_count = self.args.verbose;
+        for _ in 0..verbose_count {
+            cmd.arg("-v");
         }
 
         let child = cmd.spawn().context("Failed to spawn server process")?;


### PR DESCRIPTION
## Summary

- Forward `--buffer-size` so server uses matching transport config
- Forward `--shm-direct` flag when direct memory mode is enabled
- Forward `--pmq-priority` for POSIX message queue benchmarks
- Forward `--send-delay` so server can enable precise timestamps
- Forward `-v` verbose flags for server-side debugging

## Context

The async runner's `spawn_server_process` was missing several CLI flags that the blocking runner already forwarded correctly. This caused the server to use default values while the client used user-specified or auto-computed values, leading to potential mismatches in buffer sizes, transport modes, and logging levels.

Fixes #124

## Test plan

- [x] Full test suite passes (476 tests)
- [x] clippy clean, fmt clean, MSRV check passes

Made with [Cursor](https://cursor.com)