### PR TITLE
Fix #126: Release mutex before async write in send_to_connection

### DIFF
--- a/src/ipc/tcp_socket.rs
+++ b/src/ipc/tcp_socket.rs
@@ -461,27 +461,48 @@ impl IpcTransport for TcpSocketTransport {
         connection_id: ConnectionId,
         message: &Message,
     ) -> Result<()> {
-        let mut conns = self.connections.lock().await;
+        // Remove the stream from the map so we can release the lock
+        // before the async write, avoiding holding the mutex across
+        // an await point.
+        let mut stream = {
+            let mut conns = self.connections.lock().await;
+            conns
+                .remove(&connection_id)
+                .ok_or_else(|| anyhow!("Connection {} not found", connection_id))?
+        };
 
-        if let Some(stream) = conns.get_mut(&connection_id) {
-            Self::write_message(stream, message).await?;
-            debug!(
-                "Sent message {} to TCP connection {}",
-                message.id, connection_id
-            );
-            Ok(())
-        } else {
-            Err(anyhow!("Connection {} not found", connection_id))
+        let result = Self::write_message(&mut stream, message).await;
+
+        // Re-insert the stream regardless of write outcome so the
+        // connection remains available for future operations.
+        {
+            let mut conns = self.connections.lock().await;
+            conns.insert(connection_id, stream);
+        }
+
+        match result {
+            Ok(()) => {
+                debug!(
+                    "Sent message {} to TCP connection {}",
+                    message.id, connection_id
+                );
+                Ok(())
+            }
+            Err(e) => Err(anyhow::Error::from(e)),
         }
     }
 
     fn get_active_connections(&self) -> Vec<ConnectionId> {
-        // Note: This is a blocking operation, should be called from async context with care
-        let conns = match self.connections.try_lock() {
-            Ok(conns) => conns,
-            Err(_) => return vec![], // Return empty if locked
-        };
-        conns.keys().copied().collect()
+        match self.connections.try_lock() {
+            Ok(conns) => conns.keys().copied().collect(),
+            Err(_) => {
+                warn!(
+                    "Could not acquire connections lock in \
+                     get_active_connections; returning empty list"
+                );
+                vec![]
+            }
+        }
     }
 
     async fn close_connection(&mut self, connection_id: ConnectionId) -> Result<()> {

--- a/src/ipc/unix_domain_socket.rs
+++ b/src/ipc/unix_domain_socket.rs
@@ -426,27 +426,48 @@ impl IpcTransport for UnixDomainSocketTransport {
         connection_id: ConnectionId,
         message: &Message,
     ) -> Result<()> {
-        let mut conns = self.connections.lock().await;
+        // Remove the stream from the map so we can release the lock
+        // before the async write, avoiding holding the mutex across
+        // an await point.
+        let mut stream = {
+            let mut conns = self.connections.lock().await;
+            conns
+                .remove(&connection_id)
+                .ok_or_else(|| anyhow!("Connection {} not found", connection_id))?
+        };
 
-        if let Some(stream) = conns.get_mut(&connection_id) {
-            Self::write_message(stream, message).await?;
-            debug!(
-                "Sent message {} to Unix Domain Socket connection {}",
-                message.id, connection_id
-            );
-            Ok(())
-        } else {
-            Err(anyhow!("Connection {} not found", connection_id))
+        let result = Self::write_message(&mut stream, message).await;
+
+        // Re-insert the stream regardless of write outcome so the
+        // connection remains available for future operations.
+        {
+            let mut conns = self.connections.lock().await;
+            conns.insert(connection_id, stream);
+        }
+
+        match result {
+            Ok(()) => {
+                debug!(
+                    "Sent message {} to Unix Domain Socket connection {}",
+                    message.id, connection_id
+                );
+                Ok(())
+            }
+            Err(e) => Err(anyhow::Error::from(e)),
         }
     }
 
     fn get_active_connections(&self) -> Vec<ConnectionId> {
-        // Note: This is a blocking operation, should be called from async context with care
-        let conns = match self.connections.try_lock() {
-            Ok(conns) => conns,
-            Err(_) => return vec![], // Return empty if locked
-        };
-        conns.keys().copied().collect()
+        match self.connections.try_lock() {
+            Ok(conns) => conns.keys().copied().collect(),
+            Err(_) => {
+                warn!(
+                    "Could not acquire connections lock in \
+                     get_active_connections; returning empty list"
+                );
+                vec![]
+            }
+        }
     }
 
     async fn close_connection(&mut self, connection_id: ConnectionId) -> Result<()> {


### PR DESCRIPTION
## Summary

- Fix TCP and UDS `send_to_connection()` to not hold the connections mutex across the `write_message().await` call
- Use remove/write/re-insert pattern: take stream out of map, release lock, perform async write, re-insert stream
- Add `warn!` log in `get_active_connections()` when `try_lock()` fails, making the behavior observable
- This allows concurrent multi-client operations during writes and reduces deadlock risk

## Test plan

- [x] TCP multi-client test passes (`test_tcp_multi_client`)
- [x] UDS multi-client test passes (`test_unix_domain_socket_multi_client`)
- [x] All integration tests pass
- [x] Clippy clean, MSRV 1.70 compatible

Fixes #126

Made with [Cursor](https://cursor.com)