### PR TITLE
Fix #132: Correct README.md and CONFIG.md documentation drift

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -224,10 +224,10 @@ results/
 #### Missing Time Series Data
 ```bash
 # Problem: Only used -o parameter
-ipc-benchmark -m shm -o results/
+ipc-benchmark -m shm -o results.json
 
 # Solution: Add streaming output
-ipc-benchmark -m shm -o results/ --streaming-output-json
+ipc-benchmark -m shm -o results.json --streaming-output-json
 ```
 
 #### Missing Summary Data
@@ -236,7 +236,7 @@ ipc-benchmark -m shm -o results/ --streaming-output-json
 ipc-benchmark -m shm --streaming-output-json
 
 # Solution: Add summary output
-ipc-benchmark -m shm -o results/ --streaming-output-json
+ipc-benchmark -m shm -o results.json --streaming-output-json
 ```
 
 #### No Dashboard Data
@@ -245,7 +245,7 @@ ipc-benchmark -m shm -o results/ --streaming-output-json
 ipc-benchmark -m shm
 
 # Solution: Use both required parameters
-ipc-benchmark -m shm -o results/ --streaming-output-json
+ipc-benchmark -m shm -o results.json --streaming-output-json
 ```
 
 For dashboard setup and usage instructions, see [`utils/dashboard/README.md`](utils/dashboard/README.md).

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -5,7 +5,7 @@ This document provides detailed information about configuring the IPC Benchmark 
 ## Table of Contents
 
 - [Command Line Options](#command-line-options)
-- [Configuration File](#configuration-file)
+- [Shell Aliases for Common Configurations](#shell-aliases-for-common-configurations)
 - [Environment Variables](#environment-variables)
 - [IPC Mechanism Settings](#ipc-mechanism-settings)
 - [Performance Tuning](#performance-tuning)
@@ -23,7 +23,7 @@ This document provides detailed information about configuring the IPC Benchmark 
 | `--msg-count` | `-i` | Number | `10000` | Number of messages to send |
 | `--duration` | `-d` | String | - | Duration to run (e.g., "30s", "5m") |
 | `--concurrency` | `-c` | Number | `1` | Number of concurrent workers |
-| `--output-file` | `-o` | String | `benchmark_results.json` | Output file path |
+| `--output-file` | `-o` | String | *(none; optional flag)* | JSON output file path |
 
 ### Test Configuration
 
@@ -45,13 +45,23 @@ its own full time window.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--streaming-output` | String | - | File for streaming results during execution |
+| `--streaming-output-json` | String | - | JSON file for streaming per-message results |
+| `--streaming-output-csv` | String | - | CSV file for streaming per-message results |
 | `--continue-on-error` | Boolean | `false` | Continue running if one test fails |
-| `--verbose` | `-v` | Boolean | `false` | Enable verbose output |
+| `--verbose` | `-v` | Flag | *(repeatable)* | Increase log verbosity (-v=DEBUG, -vv=TRACE) |
+| `--quiet` | `-q` | Boolean | `false` | Suppress stdout output |
+| `--log-file` | String | `ipc_benchmark.log` | Log file path (or "stderr") |
 | `--host` | String | `"127.0.0.1"` | Host address for TCP sockets |
 | `--port` | Number | `8080` | Port for TCP sockets |
-| `--server-affinity` | Number | - | Pin the server process (message receiver) to a CPU core (best effort) |
-| `--client-affinity` | Number | - | Pin the client workload (message sender) to a CPU core (best effort) |
+| `--pmq-priority` | Number | `0` | Message priority for PMQ |
+| `--send-delay` | String | - | Delay between messages (e.g., "10ms") |
+| `--include-first-message` | Boolean | `false` | Include first message in results |
+| `--blocking` | Boolean | `false` | Use blocking I/O instead of async |
+| `--shm-direct` | Boolean | `false` | Use direct memory SHM (auto-enables blocking) |
+| `--server-affinity` | Number | - | Pin the server process (message receiver) to a CPU core |
+| `--client-affinity` | Number | - | Pin the client workload (message sender) to a CPU core |
+| `--server` | Boolean | `false` | Run in standalone server mode |
+| `--client` | Boolean | `false` | Run in standalone client mode |
 
 ### Examples
 
@@ -75,86 +85,34 @@ ipc-benchmark --percentiles 50 90 95 99 99.9 99.99 --warmup-iterations 10000
 ipc-benchmark -m shm --message-size 65536 --buffer-size 1048576
 ```
 
-## Configuration File
+## Shell Aliases for Common Configurations
 
-You can create a configuration file to avoid repeating command-line arguments:
-
-### JSON Configuration Format
-
-```json
-{
-  "mechanisms": ["uds", "shm", "tcp", "pmq"],
-  // Alternative: "mechanisms": ["all"] to test all available mechanisms
-  "message_size": 1024,
-  "msg_count": 10000,
-  "concurrency": 4,
-  "one_way": true,
-  "round_trip": true,
-  "warmup_iterations": 1000,
-  "percentiles": [50.0, 95.0, 99.0, 99.9],
-  "buffer_size": 8192,
-  "output_file": "results.json",
-  "streaming_output": "streaming.json",
-  "host": "127.0.0.1",
-  "port": 8080
-}
-```
-
-### TOML Configuration Format
-
-```toml
-mechanisms = ["uds", "shm", "tcp", "pmq"]
-# Alternative: mechanisms = ["all"]  # to test all available mechanisms
-message_size = 1024
-msg_count = 10000
-concurrency = 4
-one_way = true
-round_trip = true
-warmup_iterations = 1000
-percentiles = [50.0, 95.0, 99.0, 99.9]
-buffer_size = 8192
-output_file = "results.json"
-streaming_output = "streaming.json"
-host = "127.0.0.1"
-port = 8080
-```
-
-### Using Configuration Files
+Configuration files are not currently supported. Instead, use shell
+aliases or scripts for frequently used parameter sets:
 
 ```bash
-# JSON configuration
-ipc-benchmark --config config.json
+# Latency-focused alias
+alias ipc-latency='ipc-benchmark -m uds --message-size 64 \
+  --msg-count 100000 --warmup-iterations 10000 --send-delay 10ms'
 
-# TOML configuration
-ipc-benchmark --config config.toml
+# Throughput-focused alias
+alias ipc-throughput='ipc-benchmark -m shm --message-size 65536 \
+  --duration 60s'
 
-# Override specific options
-ipc-benchmark --config config.json --concurrency 8
+# Full comparison alias
+alias ipc-compare='ipc-benchmark -m all --message-size 1024 \
+  --msg-count 50000 --output-file comparison.json'
 ```
 
 ## Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `RUST_LOG` | Logging level (trace, debug, info, warn, error) | `info` |
-| `IPC_BENCHMARK_TEMP_DIR` | Temporary directory for IPC files | `/tmp` |
-| `IPC_BENCHMARK_OUTPUT_DIR` | Default output directory | Current directory |
-| `IPC_BENCHMARK_CONFIG` | Default configuration file path | - |
 | `CARGO_BIN_EXE_ipc-benchmark` | Path hint for the test runner to spawn the server binary | Auto-detected |
 | `CARGO_BIN_EXE_ipc_benchmark` | Alternate env var name used in some setups | Auto-detected |
 
-### Environment Variable Examples
-
-```bash
-# Enable debug logging
-RUST_LOG=debug ipc-benchmark
-
-# Use custom temporary directory
-IPC_BENCHMARK_TEMP_DIR=/var/tmp ipc-benchmark
-
-# Set default configuration
-IPC_BENCHMARK_CONFIG=./default.json ipc-benchmark
-```
+Note: Logging verbosity is controlled via the `-v` CLI flag (not
+`RUST_LOG`). Use `-v` for DEBUG, `-vv` for TRACE level output.
 
 ## IPC Mechanism Settings
 
@@ -213,30 +171,30 @@ For full dashboard compatibility, you **must** use both output parameters:
 
 | Parameter | Purpose | Dashboard Impact |
 |-----------|---------|------------------|
-| `-o <directory>` | Generate summary JSON files | Enables Summary Analysis tab |
-| `--streaming-output-json` | Generate streaming data files | Enables Time Series Analysis tab |
+| `-o <file>` | Generate summary JSON file | Enables Summary Analysis tab |
+| `--streaming-output-json` | Generate streaming data file | Enables Time Series Analysis tab |
 
 ### Example Dashboard-Ready Commands
 
 ```bash
 # Basic dashboard-compatible benchmark
-ipc-benchmark --mechanism SharedMemory --message-size 1024 \
-               -o ./dashboard_data/ \
+ipc-benchmark -m shm --message-size 1024 \
+               -o ./shm_results.json \
                --streaming-output-json
 
 # Comprehensive comparison for dashboard
 ipc-benchmark -m uds shm tcp pmq \
                --message-size 1024 \
                --msg-count 50000 \
-               -o ./results/ \
+               -o ./results.json \
                --streaming-output-json \
                --continue-on-error
 
 # Multi-size analysis
 for size in 64 256 1024 4096; do
-  ipc-benchmark --mechanism SharedMemory \
+  ipc-benchmark -m shm \
                  --message-size $size \
-                 -o ./dashboard_data/ \
+                 -o ./shm_${size}.json \
                  --streaming-output-json \
                  --duration 10s
 done
@@ -389,8 +347,7 @@ ipc-benchmark \
   --concurrency 1 \
   --warmup-iterations 10000 \
   --percentiles 50 90 95 99 99.9 99.99 \
-  --round-trip \
-  --no-one-way
+  --round-trip
 ```
 
 **Configuration:**
@@ -410,8 +367,7 @@ ipc-benchmark \
   --duration 60s \
   --concurrency 8 \
   --buffer-size 1048576 \
-  --one-way \
-  --no-round-trip
+  --one-way
 ```
 
 **Configuration:**
@@ -619,27 +575,30 @@ sudo sysctl -p
 ipcs -lm
 
 # Check available ports
-netstat -tuln | grep :8080
+ss -tuln | grep :8080
 
 # Check file permissions
 ls -la /tmp/ipc_benchmark_*
 
-# Validate configuration
-ipc-benchmark --config config.json --dry-run
+# Verify CLI options
+ipc-benchmark --help
 ```
 
 ### Performance Debugging
 
 ```bash
-# Enable detailed logging
-RUST_LOG=debug ipc-benchmark --verbose
+# Enable detailed logging (DEBUG level)
+ipc-benchmark -v -m uds -i 1000
+
+# Enable TRACE level logging
+ipc-benchmark -vv -m uds -i 100
 
 # Profile with perf
-perf record -g ipc-benchmark
+perf record -g ./target/release/ipc-benchmark -m uds -i 50000
 perf report
 
 # Memory usage analysis
-valgrind --tool=massif ipc-benchmark
+valgrind --tool=massif ./target/release/ipc-benchmark -m uds -i 1000
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -360,8 +360,8 @@ done
 ### Building from Source
 
 ```bash
-git clone https://github.com/your-org/ipc-benchmark.git
-cd ipc-benchmark
+git clone https://github.com/redhat-performance/rusty-comms.git
+cd rusty-comms
 cargo build --release
 ```
 
@@ -1090,7 +1090,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for version history and changes.
+Version history is tracked via git tags and GitHub releases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Blocking mode uses only the Rust standard library (`std::net`, `std::thread`, `s
 
 ## Shared Memory Implementations
 
-The benchmark suite provides **two shared memory implementations** for blocking mode, each optimized for different use cases:
+The benchmark suite provides **two shared memory implementations** optimized for different use cases (a third async ring buffer is used in the default async path):
 
 ### Ring Buffer (Default)
 
@@ -112,7 +112,7 @@ ipc-benchmark -m shm -i 10000
 ```
 
 **Characteristics:**
-- Works on all platforms (Linux, macOS, Windows, BSD)
+- Unix-only (Linux, macOS, BSD — uses pthread process-shared primitives)
 - Supports variable message sizes
 - Uses bincode serialization (~15-30 μs overhead)
 - Average latency: ~20 μs
@@ -144,7 +144,7 @@ ipc-benchmark -m shm --shm-direct -i 10000 --server-affinity 0 --client-affinity
 | **Max Latency** | ~10 ms | ~22 μs (450× better) |
 | **Serialization** | bincode | None (memcpy) |
 | **Message Size** | Variable | Fixed (8KB max) |
-| **Platform Support** | All | Unix only |
+| **Platform Support** | Unix (pthread) | Unix only |
 | **Best For** | Flexibility, cross-platform | Maximum performance |
 
 ### When to Use Each Implementation
@@ -155,10 +155,9 @@ ipc-benchmark -m shm --shm-direct -i 10000 --server-affinity 0 --client-affinity
 - Running on Unix/Linux systems
 
 **Use Ring Buffer (default) when:**
-- Cross-platform support is needed
 - Variable message sizes are required
 - Flexibility is more important than raw speed
-- Windows support is required
+- You want the default async mode (`-m shm` without `--blocking`)
 
 For detailed technical comparison, see [SHM_COMPARISON.md](SHM_COMPARISON.md).
 
@@ -548,6 +547,8 @@ If you need to analyze the raw performance data, including the first-message spi
 ```bash
 # Include the first message in the final results
 ipc-benchmark --include-first-message
+```
+
 ### Understanding Test Types: Throughput vs. Latency
 
 This benchmark suite can be used to measure two primary aspects of IPC performance: **throughput** and **latency**. The configuration you choose will determine which of these you are primarily testing.
@@ -991,12 +992,18 @@ To generate dashboard-compatible output, you **must** include both output parame
 
 ### File Output Expectations
 
-After running with the required parameters, you should see these files:
+After running with the required parameters, the files you specified
+are created:
 
-```
-results/
-├── sharedmemory_1024_summary.json     # Enables Summary Analysis
-└── sharedmemory_1024_streaming.json   # Enables Time Series Analysis
+```bash
+# Example: produces two files with the names you chose
+./ipc-benchmark -m shm -i 10000 \
+  -o ./shm_results.json \
+  --streaming-output-json ./shm_streaming.json
+
+# Results in:
+# ./shm_results.json          (summary/aggregated metrics)
+# ./shm_streaming.json        (per-message latency data)
 ```
 
 ### Dashboard Parameter Reference
@@ -1097,8 +1104,9 @@ See [CHANGELOG.md](CHANGELOG.md) for version history and changes.
 
 | Transport | Concurrency > 1 | Behavior |
 |-----------|----------------|----------|
-| **TCP** | ✅ Supported | Simulated concurrency (sequential tests) |
-| **Unix Domain Sockets** | ✅ Supported | Simulated concurrency (sequential tests) |
+| **TCP** | ✅ Supported | Multi-threaded workers |
+| **Unix Domain Sockets** | ✅ Supported | Multi-threaded workers |
+| **POSIX Message Queues** | ✅ Supported | Multi-threaded workers |
 | **Shared Memory** | ⚠️ **Forced to single-thread** | Automatically uses `concurrency = 1` |
 
 ### Shared Memory Limitations

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ This benchmark suite uses **high-precision monotonic clocks** to measure true IP
 
 #### Clock Source
 
-- **Unix/Linux**: Uses `CLOCK_MONOTONIC` via the nix crate
+- **Unix/Linux**: Uses `CLOCK_MONOTONIC` via direct `libc::clock_gettime` syscall
 - **Windows**: Falls back to system time (less precise)
 - **Characteristics**: Monotonic clocks measure time from system boot and are unaffected by NTP adjustments, daylight saving time, or manual clock changes
 
@@ -481,7 +481,7 @@ ipc-benchmark -m all --continue-on-error
 
 # Run only round-trip tests (one-way and round-trip run
 # sequentially by default; use these flags to select one)
-ipc-benchmark --round-trip --no-one-way
+ipc-benchmark --round-trip
 
 # Custom percentiles for latency analysis
 ipc-benchmark --percentiles 50 90 95 99 99.9 99.99
@@ -936,14 +936,11 @@ cargo test ipc
 cargo test -- --nocapture
 ```
 
-### Benchmarking
+### Profiling
 
 ```bash
-# Run internal benchmarks
-cargo bench
-
 # Profile with perf
-perf record --call-graph dwarf target/release/ipc-benchmark
+perf record --call-graph dwarf target/release/ipc-benchmark -m uds -i 50000
 perf report
 ```
 
@@ -980,14 +977,14 @@ To generate dashboard-compatible output, you **must** include both output parame
 
 ```bash
 # Minimum command for dashboard compatibility
-./ipc-benchmark --mechanism <MECHANISM> --message-size <SIZE> \
-                 -o results/ \
+./ipc-benchmark -m <MECHANISM> --message-size <SIZE> \
+                 -o results.json \
                  --streaming-output-json \
                  --continue-on-error
 
 # Example with specific values
-./ipc-benchmark --mechanism SharedMemory --message-size 1024 \
-                 -o ./benchmark_results/ \
+./ipc-benchmark -m shm --message-size 1024 \
+                 -o ./benchmark_results.json \
                  --streaming-output-json \
                  --duration 30s
 ```
@@ -1006,9 +1003,9 @@ results/
 
 | Parameter | Required | Purpose | Dashboard Impact |
 |-----------|----------|---------|------------------|
-| `-o <dir>` | **Yes** | Output directory | Summary data location |
+| `-o <file>` | **Yes** | Output JSON file path | Summary data |
 | `--streaming-output-json` | **Yes** | Enable streaming data | Time series analysis |
-| `--mechanism <type>` | **Yes** | IPC mechanism | Data categorization |
+| `-m <mechanism>` | **Yes** | IPC mechanism | Data categorization |
 | `--message-size <bytes>` | **Yes** | Message size | Performance comparison |
 | `--duration <time>` | Recommended | Test duration | Data volume |
 | `--continue-on-error` | Recommended | Continue if one test fails | Complete dataset |
@@ -1017,9 +1014,9 @@ results/
 
 #### Single Mechanism Test
 ```bash
-./ipc-benchmark --mechanism SharedMemory \
+./ipc-benchmark -m shm \
                  --message-size 1024 \
-                 -o ./dashboard_data/ \
+                 -o ./shm_results.json \
                  --streaming-output-json \
                  --duration 30s
 ```
@@ -1027,9 +1024,9 @@ results/
 #### Multi-Size Comparison Test
 ```bash
 for size in 64 256 1024 4096; do
-  ./ipc-benchmark --mechanism SharedMemory \
+  ./ipc-benchmark -m shm \
                    --message-size $size \
-                   -o ./dashboard_data/ \
+                   -o ./shm_${size}_results.json \
                    --streaming-output-json \
                    --duration 10s
 done
@@ -1038,9 +1035,9 @@ done
 #### Multi-Mechanism Comparison
 ```bash
 for mechanism in uds shm tcp pmq; do
-  ./ipc-benchmark --mechanism $mechanism \
+  ./ipc-benchmark -m $mechanism \
                    --message-size 1024 \
-                   -o ./dashboard_data/ \
+                   -o ./${mechanism}_results.json \
                    --streaming-output-json \
                    --duration 15s
 done


### PR DESCRIPTION
## Summary

- Fixes critical documentation inaccuracies in README.md and CONFIG.md where described features, CLI flags, and behaviors did not match the actual implementation
- Removes fictional features (--config file support, --dry-run, RUST_LOG env var usage, --no-one-way/--no-round-trip flags)
- Adds missing CLI flags to CONFIG.md reference table (--quiet, --send-delay, --blocking, --shm-direct, --server/--client, etc.)

## Key Fixes

| Issue | Before | After |
|-------|--------|-------|
| Clock source | "nix crate" | "direct libc::clock_gettime syscall" |
| --output-file | Documented as output directory | Correctly shown as file path |
| --streaming-output | Non-existent flag | Corrected to --streaming-output-json / --streaming-output-csv |
| Config file section | 55 lines of fictional --config support | Shell alias examples |
| Environment variables | 3 fictional env vars documented | Only actual CARGO_BIN_EXE vars |
| --no-one-way / --no-round-trip | Used in examples | Removed (flags don't exist) |
| --dry-run | Used in validation | Removed (flag doesn't exist) |
| Dashboard examples | --mechanism, -o dir/ | -m, -o file.json |

## Test plan

- [x] No code changes — documentation only
- [x] All examples use valid CLI flags verified against `ipc-benchmark --help`

Closes #132

Made with [Cursor](https://cursor.com)