### PR TITLE
chore: Update crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- Updates `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock`
- Resolves [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204): invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
- Fixes `cargo audit` CI failure affecting all branches with stale lockfile

## Details

The advisory was published 2026-07-06. Any PR receiving a fresh CI run after that date will fail the `cargo-audit` step until this lockfile update is merged into `main`.

This is a lockfile-only change — no code modifications, no `Cargo.toml` changes.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo audit` should now pass (crossbeam-epoch >=0.9.20 resolves the advisory)

Made with [Cursor](https://cursor.com)